### PR TITLE
Revert "Updated Supported Pools"

### DIFF
--- a/implementation/constants.py
+++ b/implementation/constants.py
@@ -82,33 +82,33 @@ compoundContractInfo = [
       'contract': '0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5'
     },
     {
-      'token': 'sai',
-      'contract': '0xf5dce57282a584d2746faf1593d3121fcac444dc'
+     'token': 'sai',
+     'contract': '0xf5dce57282a584d2746faf1593d3121fcac444dc'
     },
     {
-      'token': 'usdc',
-      'contract': '0x39aa39c021dfbae8fac545936693ac917d5e7563'
+     'token': 'usdc',
+     'contract': '0x39aa39c021dfbae8fac545936693ac917d5e7563'
     },
     {
-      'token': 'zrx',
-      'contract': '0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407'
+     'token': 'zrx',
+     'contract': '0xb3319f5d18bc0d84dd1b4825dcde5d5f7266d407'
     },
     {
-      'token': 'bat',
-      'contract': '0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e'
+     'token': 'bat',
+     'contract': '0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e'
     },
     {
-      'token': 'rep',
-      'contract': '0x158079ee67fce2f58472a96584a73c7ab9ac95c1'
+     'token': 'rep',
+     'contract': '0x158079ee67fce2f58472a96584a73c7ab9ac95c1'
     },
     {
-      'token': 'wbtc',
-      'contract': '0xc11b1268c1a384e55c48c2391d8d480264a3a7f4'
+     'token': 'wbtc',
+     'contract': '0xc11b1268c1a384e55c48c2391d8d480264a3a7f4'
     },
     {
       'token': 'dai',
-      'contract': '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643',
-    },
+      'contract': '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643'
+    }
 ]
 
 dydxContractInfo = {
@@ -119,123 +119,119 @@ dydxContractInfo = {
 
 fulcrumContractInfo = [
     {
-      'token': 'sai',
-      'contractAddress': '0x14094949152eddbfcd073717200da82fed8dc960',
-      'baseTokenAddress': '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
+        'token': 'sai',
+        'contractAddress': '0x14094949152eddbfcd073717200da82fed8dc960',
+        'baseTokenAddress': '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
     },
     {
-      'token': 'eth',
-      'contractAddress': '0x77f973fcaf871459aa58cd81881ce453759281bc',
-      'baseTokenAddress': '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        'token': 'eth',
+        'contractAddress': '0x77f973fcaf871459aa58cd81881ce453759281bc',
+        'baseTokenAddress': '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
     },
     {
-      'token': 'usdc',
-      'contractAddress': '0xf013406a0b1d544238083df0b93ad0d2cbe0f65f',
-      'baseTokenAddress': '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+        'token': 'usdc',
+        'contractAddress': '0xf013406a0b1d544238083df0b93ad0d2cbe0f65f',
+        'baseTokenAddress': '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
     },
     {
-      'token': 'wbtc',
-      'contractAddress': '0xba9262578efef8b3aff7f60cd629d6cc8859c8b5',
-      'baseTokenAddress': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+        'token': 'wbtc',
+        'contractAddress': '0xba9262578efef8b3aff7f60cd629d6cc8859c8b5',
+        'baseTokenAddress': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
     },
     {
-      'token': 'link',
-      'contractAddress': '0x1d496da96caf6b518b133736beca85d5c4f9cbc5',
-      'baseTokenAddress': '0x514910771af9ca656af840dff83e8264ecf986ca'
+        'token': 'rep',
+        'contractAddress': '0xbd56e9477fc6997609cf45f84795efbdac642ff1',
+        'baseTokenAddress': '0x1985365e9f78359a9B6AD760e32412f4a445E862'
     },
     {
-      'token': 'zrx',
-      'contractAddress': '0xA7Eb2bc82df18013ecC2A6C533fc29446442EDEe',
-      'baseTokenAddress': '0xe41d2489571d322189246dafa5ebde1f4699f498'
+        'token': 'link',
+        'contractAddress': '0x1d496da96caf6b518b133736beca85d5c4f9cbc5',
+        'baseTokenAddress': '0x514910771af9ca656af840dff83e8264ecf986ca'
     },
     {
-      'token': 'knc',
-      'contractAddress': '0x1cc9567ea2eb740824a45f8026ccf8e46973234d',
-      'baseTokenAddress': '0xdd974d5c2e2928dea5f71b9825b8b646686bd200'
+        'token': 'zrx',
+        'contractAddress': '0xA7Eb2bc82df18013ecC2A6C533fc29446442EDEe',
+        'baseTokenAddress': '0xe41d2489571d322189246dafa5ebde1f4699f498'
     },
     {
-      'token': 'dai',
-      'contractAddress': '0x493c57c4763932315a328269e1adad09653b9081',
-      'baseTokenAddress': '0x6b175474e89094c44da98b954eedeac495271d0f' 
+        'token': 'knc',
+        'contractAddress': '0x1cc9567ea2eb740824a45f8026ccf8e46973234d',
+        'baseTokenAddress': '0xdd974d5c2e2928dea5f71b9825b8b646686bd200' 
     },
     {
-      'token': 'susd',
-      'contractAddress': '0x49f4592E641820e928F9919Ef4aBd92a719B4b49',
-      'baseTokenAddress': '0x57ab1ec28d129707052df4df418d58a2d46d5f51',
+        'token': 'dai',
+        'contractAddress': '0x493c57c4763932315a328269e1adad09653b9081',
+        'baseTokenAddress': '0x6b175474e89094c44da98b954eedeac495271d0f' 
     }
 ]
 
 nuoContractInfo = [
     {
-      'token': 'sai',
-      'baseTokenAddress': '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
+        'token': 'sai',
+        'baseTokenAddress': '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
     },
     {
-      'token': 'eth',
-      'baseTokenAddress': '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+        'token': 'eth',
+        'baseTokenAddress': '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
     },
     {
-      'token': 'usdc',
-      'baseTokenAddress': '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+        'token': 'usdc',
+        'baseTokenAddress': '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
     },
     {
-      'token': 'wbtc',
-      'baseTokenAddress': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
+        'token': 'wbtc',
+        'baseTokenAddress': '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599'
     },
     {
-      'token': 'rep',
-      'baseTokenAddress': '0x1985365e9f78359a9B6AD760e32412f4a445E862'
+        'token': 'rep',
+        'baseTokenAddress': '0x1985365e9f78359a9B6AD760e32412f4a445E862'
     },
     {
-      'token': 'link',
-      'baseTokenAddress': '0x514910771af9ca656af840dff83e8264ecf986ca'
+        'token': 'link',
+        'baseTokenAddress': '0x514910771af9ca656af840dff83e8264ecf986ca'
     },
     {
-      'token': 'knc',
-      'baseTokenAddress': '0xdd974d5c2e2928dea5f71b9825b8b646686bd200'
+        'token': 'zrx',
+        'baseTokenAddress': '0xe41d2489571d322189246dafa5ebde1f4699f498'
     },
     {
-      'token': 'mkr',
-      'baseTokenAddress': '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2'
+        'token': 'knc',
+        'baseTokenAddress': '0xdd974d5c2e2928dea5f71b9825b8b646686bd200'
+
     },
     {
-      'token': 'tusd',
-      'baseTokenAddress': '0x8dd5fbce2f6a956c3022ba3663759011dd51e73e'
+        'token': 'mkr',
+        'baseTokenAddress': '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2'
+
     },
     {
-      'token': 'bat',
-      'baseTokenAddress': '0x0d8775f648430679a709e98d2b0cb6250d2887ef'
+        'token': 'tusd',
+        'baseTokenAddress': '0x8dd5fbce2f6a956c3022ba3663759011dd51e73e'
+
     },
     {
-      'token': 'snx',
-      'baseTokenAddress': '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f'
-    },
-    {
-      'token': 'dai',
-      'baseTokenAddress': '0x6b175474e89094c44da98b954eedeac495271d0f'
+        'token': 'bat',
+        'baseTokenAddress': '0x0d8775f648430679a709e98d2b0cb6250d2887ef'
+
     }
 ]
 
 ddexContractInfo = [
     {
-      'token': 'sai',
-      'baseTokenAddress': '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
+        'token': 'sai',
+        'baseTokenAddress': '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
     },
     {
-      'token': 'eth',
-      'baseTokenAddress': '0x000000000000000000000000000000000000000e'
+        'token': 'eth',
+        'baseTokenAddress': '0x000000000000000000000000000000000000000e'
     },
     {
-      'token': 'wbtc',
-      'baseTokenAddress': '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
+        'token': 'usdt',
+        'baseTokenAddress': '0xdac17f958d2ee523a2206206994597c13d831ec7'
     },
     {
       'token': 'dai',
-      'baseTokenAddress': '0x6B175474E89094C44Da98b954EedeAC495271d0F'
-    },
-    {
-      'token': 'usdt',
-      'baseTokenAddress': '0xdac17f958d2ee523a2206206994597c13d831ec7'
+      'baseTokenAddress': '0x6b175474e89094c44da98b954eedeac495271d0f'
     },
     {
       'token': 'usdc',
@@ -294,10 +290,12 @@ aaveContractInfo = [
     },
     {
       'token': 'snx',
+      'contractAddress': '0x398eC7346DcD622eDc5ae82352F02bE94C62d119',
       'baseTokenAddress': '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
     },
     {
       'token': 'susd',
+      'contractAddress': '0x398eC7346DcD622eDc5ae82352F02bE94C62d119',
       'baseTokenAddress': '0x57ab1ec28d129707052df4df418d58a2d46d5f51',
     },
 ]

--- a/implementation/data.json
+++ b/implementation/data.json
@@ -4,26 +4,43 @@
         "protocol": "dydx",
         "metrics": {
             "score": "8.2",
-            "liquidityIndex": "0.8592376902313974",
-            "collateralIndex": "0.9347612497162907"
+<<<<<<< HEAD
+            "liquidityIndex": "0.8482063631096705",
+            "collateralIndex": "0.928104142214458"
+=======
+            "liquidityIndex": "0.8619296920461292",
+            "collateralIndex": "0.8895022838909773"
+>>>>>>> master
         }
     },
     {
         "asset": "usdc",
         "protocol": "dydx",
         "metrics": {
+<<<<<<< HEAD
+            "score": "6.9",
+            "liquidityIndex": "0.4951586188015955",
+            "collateralIndex": "0.01645823827231918"
+=======
             "score": "7.0",
-            "liquidityIndex": "0.5442535948703474",
+            "liquidityIndex": "0.5974266183280299",
             "collateralIndex": "0.0"
+>>>>>>> master
         }
     },
     {
         "asset": "dai",
         "protocol": "dydx",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.5370310412405006",
-            "collateralIndex": "0.09175070545080455"
+<<<<<<< HEAD
+            "score": "6.8",
+            "liquidityIndex": "0.4236890769366236",
+            "collateralIndex": "0.0"
+=======
+            "score": "7.4",
+            "liquidityIndex": "0.6696872789539287",
+            "collateralIndex": "0.2638578902666132"
+>>>>>>> master
         }
     },
     {
@@ -32,25 +49,40 @@
         "metrics": {
             "score": "8.3",
             "liquidityIndex": "1.0",
-            "collateralIndex": "0.9892226226042078"
+<<<<<<< HEAD
+            "collateralIndex": "0.9899560832686515"
+=======
+            "collateralIndex": "0.9922840619184964"
+>>>>>>> master
         }
     },
     {
         "asset": "sai",
         "protocol": "compound",
         "metrics": {
+<<<<<<< HEAD
             "score": "7.6",
-            "liquidityIndex": "0.6863142502986896",
-            "collateralIndex": "0.584941044702947"
+            "liquidityIndex": "0.6834037015327478",
+            "collateralIndex": "0.6085264804818649"
+=======
+            "score": "7.8",
+            "liquidityIndex": "0.8150778101908394",
+            "collateralIndex": "0.6909574739655315"
+>>>>>>> master
         }
     },
     {
         "asset": "usdc",
         "protocol": "compound",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.8582851302878575",
-            "collateralIndex": "0.41744973907681004"
+            "score": "7.7",
+<<<<<<< HEAD
+            "liquidityIndex": "0.8576556914394681",
+            "collateralIndex": "0.4662973910721059"
+=======
+            "liquidityIndex": "0.9141492071378332",
+            "collateralIndex": "0.49063894781815365"
+>>>>>>> master
         }
     },
     {
@@ -58,8 +90,13 @@
         "protocol": "compound",
         "metrics": {
             "score": "7.9",
-            "liquidityIndex": "0.6065727267896296",
-            "collateralIndex": "0.9284229546345295"
+<<<<<<< HEAD
+            "liquidityIndex": "0.6040541523986142",
+            "collateralIndex": "0.9351629640123271"
+=======
+            "liquidityIndex": "0.6426253387017546",
+            "collateralIndex": "0.9486421851090178"
+>>>>>>> master
         }
     },
     {
@@ -67,8 +104,13 @@
         "protocol": "compound",
         "metrics": {
             "score": "7.8",
-            "liquidityIndex": "0.5710974315134446",
-            "collateralIndex": "0.9094650579450917"
+<<<<<<< HEAD
+            "liquidityIndex": "0.5585907274324715",
+            "collateralIndex": "0.9076846810248812"
+=======
+            "liquidityIndex": "0.5811106765201056",
+            "collateralIndex": "0.9126242681494148"
+>>>>>>> master
         }
     },
     {
@@ -76,8 +118,13 @@
         "protocol": "compound",
         "metrics": {
             "score": "8.2",
-            "liquidityIndex": "0.8827832014847731",
-            "collateralIndex": "0.9941791901200796"
+<<<<<<< HEAD
+            "liquidityIndex": "0.895636435569794",
+            "collateralIndex": "0.9924332320481611"
+=======
+            "liquidityIndex": "0.8884391536649425",
+            "collateralIndex": "0.9947940909894281"
+>>>>>>> master
         }
     },
     {
@@ -85,35 +132,42 @@
         "protocol": "compound",
         "metrics": {
             "score": "7.8",
-            "liquidityIndex": "0.6055861863097011",
-            "collateralIndex": "0.8525629869537762"
+<<<<<<< HEAD
+            "liquidityIndex": "0.5923267759223696",
+            "collateralIndex": "0.8528564158749234"
+=======
+            "liquidityIndex": "0.613232115985759",
+            "collateralIndex": "0.8383301229184532"
+>>>>>>> master
         }
     },
     {
         "asset": "dai",
         "protocol": "compound",
         "metrics": {
-            "score": "7.2",
-            "liquidityIndex": "0.7491336418915462",
-            "collateralIndex": "0.15677298513598492"
-        }
-    },
-    {
-        "asset": "dai",
-        "protocol": "fulcrum",
-        "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.6697236038782413",
-            "collateralIndex": "0.5754508726592501"
+            "score": "7.5",
+<<<<<<< HEAD
+            "liquidityIndex": "0.806769250167769",
+            "collateralIndex": "0.3688489734805932"
+=======
+            "liquidityIndex": "0.8157414565469526",
+            "collateralIndex": "0.3507275225047414"
+>>>>>>> master
         }
     },
     {
         "asset": "sai",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.4752138675698243",
-            "collateralIndex": "0.6218316171516947"
+<<<<<<< HEAD
+            "score": "7.4",
+            "liquidityIndex": "0.4356565123515526",
+            "collateralIndex": "0.41542043496884284"
+=======
+            "score": "7.5",
+            "liquidityIndex": "0.5426370595559742",
+            "collateralIndex": "0.4787328624931214"
+>>>>>>> master
         }
     },
     {
@@ -121,71 +175,131 @@
         "protocol": "fulcrum",
         "metrics": {
             "score": "8.0",
-            "liquidityIndex": "0.5541063059671661",
-            "collateralIndex": "0.9742257633161726"
+<<<<<<< HEAD
+            "liquidityIndex": "0.5376471379783879",
+            "collateralIndex": "0.9912893699508256"
+=======
+            "liquidityIndex": "0.5404116392608819",
+            "collateralIndex": "0.9068362450632222"
+>>>>>>> master
         }
     },
     {
         "asset": "usdc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.34491372014941385",
-            "collateralIndex": "0.08733426468407957"
+            "score": "7.4",
+<<<<<<< HEAD
+            "liquidityIndex": "0.42766106262390124",
+            "collateralIndex": "0.4051632057482891"
+=======
+            "liquidityIndex": "0.4828641151582046",
+            "collateralIndex": "0.4096980688753241"
+>>>>>>> master
         }
     },
     {
         "asset": "wbtc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.43177096570802626",
-            "collateralIndex": "0.8666254532492241"
+            "score": "7.9",
+<<<<<<< HEAD
+            "liquidityIndex": "0.4479755510181863",
+            "collateralIndex": "0.8912022094145013"
+=======
+            "liquidityIndex": "0.38173622281071196",
+            "collateralIndex": "0.9696124328914818"
+>>>>>>> master
+        }
+    },
+    {
+        "asset": "rep",
+        "protocol": "fulcrum",
+        "metrics": {
+<<<<<<< HEAD
+            "score": "7.7",
+            "liquidityIndex": "0.14412940504208685",
+            "collateralIndex": "1.0"
+=======
+            "score": "7.6",
+            "liquidityIndex": "0.13446703650578085",
+            "collateralIndex": "0.9954633461008903"
+>>>>>>> master
         }
     },
     {
         "asset": "link",
         "protocol": "fulcrum",
         "metrics": {
+<<<<<<< HEAD
+            "score": "7.9",
+            "liquidityIndex": "0.3482833666218368",
+            "collateralIndex": "0.999243190173935"
+=======
             "score": "7.8",
-            "liquidityIndex": "0.2985942344139382",
-            "collateralIndex": "0.99993864831974"
+            "liquidityIndex": "0.3516676503682648",
+            "collateralIndex": "0.9660290992319817"
+>>>>>>> master
         }
     },
     {
         "asset": "zrx",
         "protocol": "fulcrum",
         "metrics": {
+<<<<<<< HEAD
             "score": "7.6",
-            "liquidityIndex": "0.14682453474508728",
-            "collateralIndex": "0.9227246565795725"
+            "liquidityIndex": "0.12928476219061705",
+            "collateralIndex": "0.9268709036808443"
+=======
+            "score": "7.5",
+            "liquidityIndex": "0.09601366164723893",
+            "collateralIndex": "0.8816971817301292"
+>>>>>>> master
         }
     },
     {
         "asset": "knc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.9",
-            "liquidityIndex": "0.3493270238982441",
-            "collateralIndex": "0.9976925605818618"
+<<<<<<< HEAD
+            "score": "7.3",
+            "liquidityIndex": "0.1438963927401767",
+            "collateralIndex": "0.6427484027850111"
+=======
+            "score": "7.2",
+            "liquidityIndex": "0.12943599532728525",
+            "collateralIndex": "0.5187451682651569"
+>>>>>>> master
         }
     },
     {
-        "asset": "susd",
+        "asset": "dai",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.25484397863449193",
-            "collateralIndex": "0.4931036294596718"
+<<<<<<< HEAD
+            "score": "7.9",
+            "liquidityIndex": "0.6592674171379387",
+            "collateralIndex": "0.7502645791885646"
+=======
+            "score": "7.8",
+            "liquidityIndex": "0.5942345848687786",
+            "collateralIndex": "0.6820484868660319"
+>>>>>>> master
         }
     },
     {
         "asset": "sai",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.0",
-            "liquidityIndex": "0.47437722828194284",
-            "collateralIndex": "0.650938778285884"
+<<<<<<< HEAD
+            "score": "4.3",
+            "liquidityIndex": "0.49221845685921417",
+            "collateralIndex": "0.9258161190769627"
+=======
+            "score": "4.2",
+            "liquidityIndex": "0.5362619994487701",
+            "collateralIndex": "0.7509663092988136"
+>>>>>>> master
         }
     },
     {
@@ -193,44 +307,88 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.3",
-            "liquidityIndex": "0.4955242141591791",
-            "collateralIndex": "0.9625175637003424"
+<<<<<<< HEAD
+            "liquidityIndex": "0.4799528569958016",
+            "collateralIndex": "0.9631305885621394"
+=======
+            "liquidityIndex": "0.5204214607514014",
+            "collateralIndex": "0.9186589470415549"
+>>>>>>> master
         }
     },
     {
         "asset": "usdc",
         "protocol": "nuo",
         "metrics": {
-            "score": "3.9",
-            "liquidityIndex": "0.49146829625728883",
-            "collateralIndex": "0.5634932544857769"
+<<<<<<< HEAD
+            "score": "4.2",
+            "liquidityIndex": "0.5203105728353173",
+            "collateralIndex": "0.7746931631465399"
+=======
+            "score": "4.5",
+            "liquidityIndex": "0.6730336430480628",
+            "collateralIndex": "0.8762582761061741"
+>>>>>>> master
         }
     },
     {
         "asset": "wbtc",
         "protocol": "nuo",
         "metrics": {
+<<<<<<< HEAD
+            "score": "4.3",
+            "liquidityIndex": "0.4491704513463853",
+            "collateralIndex": "0.9338543221774446"
+=======
             "score": "4.2",
-            "liquidityIndex": "0.45889431770866274",
-            "collateralIndex": "0.929570480595231"
+            "liquidityIndex": "0.473984361301469",
+            "collateralIndex": "0.8749064567514107"
+>>>>>>> master
         }
     },
     {
         "asset": "rep",
         "protocol": "nuo",
         "metrics": {
+<<<<<<< HEAD
+            "score": "4.0",
+            "liquidityIndex": "0.24208669599719917",
+            "collateralIndex": "0.9072977690865307"
+=======
             "score": "4.1",
-            "liquidityIndex": "0.24626505549825237",
-            "collateralIndex": "0.9755230574856182"
+            "liquidityIndex": "0.24404529873821212",
+            "collateralIndex": "1.0"
+>>>>>>> master
         }
     },
     {
         "asset": "link",
         "protocol": "nuo",
         "metrics": {
+<<<<<<< HEAD
+            "score": "4.2",
+            "liquidityIndex": "0.3761377391417449",
+            "collateralIndex": "0.997725596017497"
+=======
             "score": "4.3",
-            "liquidityIndex": "0.39908471441641435",
-            "collateralIndex": "1.0"
+            "liquidityIndex": "0.3953907529082451",
+            "collateralIndex": "0.9994235612803878"
+>>>>>>> master
+        }
+    },
+    {
+        "asset": "zrx",
+        "protocol": "nuo",
+        "metrics": {
+<<<<<<< HEAD
+            "score": "3.8",
+            "liquidityIndex": "0.03475757448308245",
+            "collateralIndex": "0.8629841279083283"
+=======
+            "score": "4.0",
+            "liquidityIndex": "0.11989943940913511",
+            "collateralIndex": "0.9951617378418989"
+>>>>>>> master
         }
     },
     {
@@ -238,17 +396,28 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.2",
-            "liquidityIndex": "0.377908868817463",
-            "collateralIndex": "0.9609511187382254"
+<<<<<<< HEAD
+            "liquidityIndex": "0.3586272352278694",
+            "collateralIndex": "0.9586476716771716"
+=======
+            "liquidityIndex": "0.37038306436652935",
+            "collateralIndex": "0.9504082115405663"
+>>>>>>> master
         }
     },
     {
         "asset": "mkr",
         "protocol": "nuo",
         "metrics": {
+<<<<<<< HEAD
             "score": "3.8",
-            "liquidityIndex": "0.11431837734291385",
-            "collateralIndex": "0.864946496690706"
+            "liquidityIndex": "0.10405098998003937",
+            "collateralIndex": "0.8554762843137367"
+=======
+            "score": "3.0",
+            "liquidityIndex": "0.0",
+            "collateralIndex": "0.056963901937247985"
+>>>>>>> master
         }
     },
     {
@@ -256,8 +425,13 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.0",
-            "liquidityIndex": "0.22170459126492265",
-            "collateralIndex": "0.9484588495076368"
+<<<<<<< HEAD
+            "liquidityIndex": "0.20497729737016612",
+            "collateralIndex": "0.9512391884097343"
+=======
+            "liquidityIndex": "0.25364110038611887",
+            "collateralIndex": "0.8145193178695206"
+>>>>>>> master
         }
     },
     {
@@ -265,35 +439,13 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.2",
-            "liquidityIndex": "0.32620431044203163",
-            "collateralIndex": "1.0"
-        }
-    },
-    {
-        "asset": "snx",
-        "protocol": "nuo",
-        "metrics": {
-            "score": "3.3",
-            "liquidityIndex": "0.17133757074295683",
-            "collateralIndex": "0.2764297815761211"
-        }
-    },
-    {
-        "asset": "dai",
-        "protocol": "nuo",
-        "metrics": {
-            "score": "4.1",
-            "liquidityIndex": "0.3063148618614177",
-            "collateralIndex": "0.8864859542771436"
-        }
-    },
-    {
-        "asset": "eth",
-        "protocol": "ddex",
-        "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.41484141510829287",
-            "collateralIndex": "0.6818202327267436"
+<<<<<<< HEAD
+            "liquidityIndex": "0.308191100419485",
+            "collateralIndex": "0.9758752122805517"
+=======
+            "liquidityIndex": "0.33084593060855516",
+            "collateralIndex": "0.9808007683578874"
+>>>>>>> master
         }
     },
     {
@@ -301,89 +453,103 @@
         "protocol": "ddex",
         "metrics": {
             "score": "7.4",
-            "liquidityIndex": "0.20905176355962377",
+<<<<<<< HEAD
+            "liquidityIndex": "0.19245342691260733",
+=======
+            "liquidityIndex": "0.23916896307565613",
+>>>>>>> master
             "collateralIndex": "1.0"
         }
     },
     {
-        "asset": "wbtc",
+        "asset": "eth",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.2",
-            "liquidityIndex": "0.0",
-            "collateralIndex": "1.0"
-        }
-    },
-    {
-        "asset": "dai",
-        "protocol": "ddex",
-        "metrics": {
-            "score": "6.7",
-            "liquidityIndex": "0.16679009894312483",
-            "collateralIndex": "0.29483877195737307"
+<<<<<<< HEAD
+            "score": "7.3",
+            "liquidityIndex": "0.3914880050717798",
+            "collateralIndex": "0.657636885697614"
+=======
+            "score": "7.5",
+            "liquidityIndex": "0.4534596914009832",
+            "collateralIndex": "0.8084646856717396"
+>>>>>>> master
         }
     },
     {
         "asset": "usdt",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.4",
-            "liquidityIndex": "0.516365595540751",
-            "collateralIndex": "0.6828241519110949"
+<<<<<<< HEAD
+            "score": "7.0",
+            "liquidityIndex": "0.33907726883013906",
+            "collateralIndex": "0.4455996403860234"
+=======
+            "score": "7.2",
+            "liquidityIndex": "0.23909349959243895",
+            "collateralIndex": "0.754645268342757"
+>>>>>>> master
         }
     },
     {
         "asset": "dai",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.7",
-            "liquidityIndex": "0.16679009894312483",
-            "collateralIndex": "0.29483877195737307"
+<<<<<<< HEAD
+            "score": "6.9",
+            "liquidityIndex": "0.23792768684552265",
+            "collateralIndex": "0.4975973355794766"
+=======
+            "score": "6.8",
+            "liquidityIndex": "0.2552641421285499",
+            "collateralIndex": "0.35965823794080565"
+>>>>>>> master
         }
     },
     {
         "asset": "usdc",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.41369657929516535",
-            "collateralIndex": "0.6370222935619521"
+<<<<<<< HEAD
+            "score": "7.6",
+            "liquidityIndex": "0.4370805669973625",
+            "collateralIndex": "0.985659165770443"
         }
     },
     {
         "asset": "eth",
         "protocol": "aave",
         "metrics": {
-            "score": "7.7",
-            "liquidityIndex": "0.5792249358368281",
-            "collateralIndex": "0.906105758829674"
+            "score": "7.6",
+            "liquidityIndex": "0.48834021344257916",
+            "collateralIndex": "0.9002778749577542"
         }
     },
     {
         "asset": "usdc",
         "protocol": "aave",
         "metrics": {
-            "score": "6.5",
-            "liquidityIndex": "0.14367881930077772",
-            "collateralIndex": "0.1444836592127835"
+            "score": "6.3",
+            "liquidityIndex": "0.0",
+            "collateralIndex": "0.1122496557325362"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "aave",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.35026487531604217",
-            "collateralIndex": "0.9886607491285847"
+            "score": "7.5",
+            "liquidityIndex": "0.3250309141221338",
+            "collateralIndex": "0.9880928246442178"
         }
     },
     {
         "asset": "link",
         "protocol": "aave",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.628882654462202",
-            "collateralIndex": "0.9578723708843812"
+            "score": "7.6",
+            "liquidityIndex": "0.4754412910752708",
+            "collateralIndex": "0.8937414942136553"
         }
     },
     {
@@ -391,8 +557,8 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.4",
-            "liquidityIndex": "0.22743707697439935",
-            "collateralIndex": "0.9863847824351871"
+            "liquidityIndex": "0.20635572107643116",
+            "collateralIndex": "0.9990101343293879"
         }
     },
     {
@@ -400,80 +566,85 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.6",
-            "liquidityIndex": "0.38008699179130556",
-            "collateralIndex": "0.9927140661481465"
+            "liquidityIndex": "0.3595880366528474",
+            "collateralIndex": "0.9987124178227765"
         }
     },
     {
         "asset": "dai",
         "protocol": "aave",
         "metrics": {
-            "score": "6.9",
-            "liquidityIndex": "0.3726542025758556",
-            "collateralIndex": "0.31406386068626013"
+            "score": "6.6",
+            "liquidityIndex": "0.23771333804334718",
+            "collateralIndex": "0.15023685445643176"
         }
     },
     {
         "asset": "bat",
         "protocol": "aave",
         "metrics": {
-            "score": "7.5",
-            "liquidityIndex": "0.2613347656968942",
-            "collateralIndex": "0.9863965967487084"
+            "score": "7.4",
+            "liquidityIndex": "0.22945415661398832",
+            "collateralIndex": "0.9842308738006139"
         }
     },
     {
         "asset": "lend",
         "protocol": "aave",
         "metrics": {
-            "score": "7.7",
-            "liquidityIndex": "0.5390248728301618",
-            "collateralIndex": "0.9701305245817321"
+            "score": "7.6",
+            "liquidityIndex": "0.4734714885050531",
+            "collateralIndex": "0.903625864736977"
         }
     },
     {
         "asset": "mkr",
         "protocol": "aave",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.34688313143566507",
-            "collateralIndex": "0.9901367581952748"
+            "score": "7.5",
+            "liquidityIndex": "0.318395869128073",
+            "collateralIndex": "0.988570177308151"
         }
     },
     {
         "asset": "tusd",
         "protocol": "aave",
         "metrics": {
-            "score": "6.8",
-            "liquidityIndex": "0.2890720636500724",
-            "collateralIndex": "0.32562061607566417"
+            "score": "7.0",
+            "liquidityIndex": "0.2944494099397984",
+            "collateralIndex": "0.4650864731202252"
         }
     },
     {
         "asset": "usdt",
         "protocol": "aave",
         "metrics": {
-            "score": "6.9",
-            "liquidityIndex": "0.47108282708875243",
-            "collateralIndex": "0.1954530861016215"
+            "score": "7.5",
+            "liquidityIndex": "0.550264921019968",
+            "collateralIndex": "0.7158848688437611"
         }
     },
     {
         "asset": "snx",
         "protocol": "aave",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.3433427799790493",
-            "collateralIndex": "0.7889756186347942"
+            "score": "6.9",
+            "liquidityIndex": "0.16908479212663619",
+            "collateralIndex": "0.5440453544704522"
         }
     },
     {
         "asset": "susd",
         "protocol": "aave",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.23730729786462135",
-            "collateralIndex": "0.5191217411798812"
+            "score": "7.2",
+            "liquidityIndex": "0.2451472942213502",
+            "collateralIndex": "0.7394504501095933"
+=======
+            "score": "7.7",
+            "liquidityIndex": "0.48078644109967006",
+            "collateralIndex": "0.9926240799219329"
+>>>>>>> master
         }
     }
 ]

--- a/implementation/finance_service.py
+++ b/implementation/finance_service.py
@@ -39,7 +39,7 @@ def getReturns(tokens):
             token = token['token'][1:].upper()
         else:
             token = token['token'].upper()
-        if (token in ['DAI', 'USDC', 'MKR', 'TUSD', 'USDT', 'SAI', 'SUSD', 'SNX']):
+        if (token == 'DAI' or token == 'USDC' or token == 'MKR' or token == 'TUSD' or token == 'USDT' or token == 'SAI'):
             if token == 'SAI':
                 token = 'DAI'
             ticker_returns = getCryptoCompareReturns(token)


### PR DESCRIPTION
## What this does:
* Reverts ConsenSys/defi-score#31


### Why?
I need to rewrite the commit message of the previous merge because I have fat fingers and clicked `Squash and Merge` too quickly before adding the correct versioning message.

A new PR will be opened that contains the cherrypicked merge in question.