### PR TITLE
Updated Smart Contract Security Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ The DeFi Score methodology can be organized into Smart Contract Risk, Financial 
 
 ### I. Smart Contract Risk
 
-* #### Smart Contract Security (35%)
+* #### Smart Contract Security (45%)
   Errors, bugs and unexpected outcomes in smart contracts can cause real financial harm. These risks can be minimized by proactive code audits and formal verification from reputable security firms.
 
   Our model assesses code security by looking at three pieces of off-chain but public data:
 
-  1. **Audited Code:** Has the code been audited by a reputable security team?
-  2. **Formal Verification:** Has the code been formally verified by a reputable security team?
-  3. **Bounty Program:** Does the development team offers a public bug bounty program?
-
-* #### Smart Contract Openness (10%)
-  Part of the promise of DeFi is that the functionality of smart contracts is completely on-chain, which means they are verifiable and transparent. Developers of DeFi platforms still have the ability to obscure their code in various ways, such as not verifying the bytecode and using off chain oracles processes. Security through obscurity offers weak security guarantees at best, and at worst results in delays in finding critical bugs.
+  1. **Time on Mainnet** Normalized time since the protocol first launched on mainnet
+  2. **No Critical Vulnerabilities:** No vulnerabilities have been exploited
+  3. **Four Engineer Weeks** 4 or more engineer weeks have been dedicated to auditing the protocol
+  4. **Public Audit:** Has the audit report been made public
+  5. **Recent Audit:** Has there been an audit in the last 12 months **OR** have no code changes been made
+  6. **Bounty Program:** Does the development team offers a public bug bounty program?
 
 ### II. Financial Risk
 

--- a/implementation/__main__.py
+++ b/implementation/__main__.py
@@ -27,7 +27,8 @@ def calculate_score(protocol, token, liquidity_value, collateral_value):
             'score': score,
             'liquidityIndex': str(liquidity_value),
             'collateralIndex': str(collateral_value),
-            'centralizationIndex': str(protocol_values['centralizationRisk'])
+            'centralizationIndex': str(protocol_values['centralizationRisk']),
+            'timIndex': str(protocol_values['timeIndex'])
         }
     }
     return result
@@ -55,7 +56,8 @@ def main():
         constants.nuo_values['operatingWithoutExploitSince'],
         constants.fulcrum_values['operatingWithoutExploitSince'],
         constants.ddex_values['operatingWithoutExploitSince'],
-        constants.dydx_values['operatingWithoutExploitSince']
+        constants.dydx_values['operatingWithoutExploitSince'],
+        constants.maker_values['operatingWithoutExploitSince']
     ]
 
     # Pulling and calculating Compound data
@@ -112,7 +114,9 @@ def main():
     'asset': 'dai',
     'protocol': 'mcd',
     'metrics': {
-        'score': 9.7
+        'score': '9.7',
+        'timeIndex': '1',
+        'centralizationIndex': '0.875'
     }
     })
 

--- a/implementation/__main__.py
+++ b/implementation/__main__.py
@@ -11,11 +11,13 @@ def calculate_score(protocol, token, liquidity_value, collateral_value):
         protocol_values = constants.fulcrum_values
     elif protocol == 'nuo':
         protocol_values = constants.nuo_values
+    elif protocol == 'aave':
+        protocol_values = constants.aave_values
     else:
         protocol_values = constants.ddex_values
     
     weights = constants.weights
-    score = weights['auditedCode'] * protocol_values['isCodeAudited'] + weights['allCodeOSS'] * protocol_values['isCodeOpenSource'] + weights['formalVer'] * protocol_values['isCodeFormallyVerified'] + weights['hasBugBounty'] * protocol_values['hasBugBounty'] + weights['cVaR'] * protocol_values['cvar'] + weights['poolCollateralization'] * collateral_value + weights['poolLiquidity'] * liquidity_value + weights['centralizationRisk'] * protocol_values['centralizationRisk']
+    score = weights['engineeringWeeks'] * protocol_values['fourEngineeringWeeks'] + weights['noCriticalVulns'] * protocol_values['noCriticalVulns'] + weights['recentOrNoCodeChanges'] * protocol_values['recentAuditOrNoCodeChanges'] + weights['timeIndex'] * protocol_values['timeIndex'] + weights['hasBugBounty'] * protocol_values['hasBugBounty'] + weights['cVaR'] * protocol_values['cvar'] + weights['poolCollateralization'] * collateral_value + weights['poolLiquidity'] * liquidity_value + weights['centralizationRisk'] * protocol_values['centralizationRisk']
     score = round(score, 2) * 10
     score = "{:.1f}".format(score)
     result = {
@@ -32,7 +34,6 @@ def calculate_score(protocol, token, liquidity_value, collateral_value):
 def calculate_scores():
     # Get all pool data
     all_pool_data = pool_data_service.fetch_data_for_all_pools()
-    test = [p for p in all_pool_data if p['liquidity'] == 0]
     liquidity_array = [math.log(p['liquidity']) for p in all_pool_data]
     utilization_array = [p['utilizationRate'] for p in all_pool_data]
     results = []
@@ -45,56 +46,78 @@ def calculate_scores():
     return results
 
 def main():
-  print('Beginning score calculation...')
+    print('Beginning score calculation...')
 
-  # Pulling and calculating Compound data
-  compound_tokens = [x['token'] for x in constants.compoundContractInfo]
-  compound_balances = [pool_data_service.fetch_data_for_pool('compound', t) for t in compound_tokens]
-  compound_portfolio_cvar = finance_service.generate_cvar_from_balances(compound_balances)
-  # add instead of subtract here because cvar from this function is negative
-  constants.compound_values['cvar'] = 1 + compound_portfolio_cvar
+    time_list = [
+        constants.compound_values['operatingWithoutExploitSince'],
+        constants.aave_values['operatingWithoutExploitSince'],
+        constants.nuo_values['operatingWithoutExploitSince'],
+        constants.fulcrum_values['operatingWithoutExploitSince'],
+        constants.ddex_values['operatingWithoutExploitSince'],
+        constants.dydx_values['operatingWithoutExploitSince']
+    ]
 
-  # Pulling and calculating dYdX data
-  dydx_tokens = constants.dydxContractInfo['activeMarkets']
-  dydx_balances = [pool_data_service.fetch_data_for_pool('dydx', t) for t in dydx_tokens]
-  dydx_portfolio_cvar = finance_service.generate_cvar_from_balances(dydx_balances)
-  # add instead of subtract here because cvar from this function is negative
-  constants.dydx_values['cvar'] = 1 + dydx_portfolio_cvar
+    # Pulling and calculating Compound data
+    compound_tokens = [x['token'] for x in constants.compoundContractInfo]
+    compound_balances = [pool_data_service.fetch_data_for_pool('compound', t) for t in compound_tokens]
+    compound_portfolio_cvar = finance_service.generate_cvar_from_balances(compound_balances)
+    # add instead of subtract here because cvar from this function is negative
+    constants.compound_values['cvar'] = 1 + compound_portfolio_cvar
+    constants.compound_values['timeIndex'] = finance_service.normalize_time_data(constants.compound_values['operatingWithoutExploitSince'], time_list)
 
-  # Pulling and calculating Fulcrum data
-  fulcrum_tokens = [x['token'] for x in constants.fulcrumContractInfo]
-  fulcrum_balances = [pool_data_service.fetch_data_for_pool('fulcrum', t) for t in fulcrum_tokens]
-  fulcrum_portfolio_cvar = finance_service.generate_cvar_from_balances(fulcrum_balances)
-  # add instead of subtract here because cvar from this function is negative
-  constants.fulcrum_values['cvar'] = 1 + fulcrum_portfolio_cvar
+    # Pulling and calculating dYdX data
+    dydx_tokens = constants.dydxContractInfo['activeMarkets']
+    dydx_balances = [pool_data_service.fetch_data_for_pool('dydx', t) for t in dydx_tokens]
+    dydx_portfolio_cvar = finance_service.generate_cvar_from_balances(dydx_balances)
+    # add instead of subtract here because cvar from this function is negative
+    constants.dydx_values['cvar'] = 1 + dydx_portfolio_cvar
+    constants.dydx_values['timeIndex'] = finance_service.normalize_time_data(constants.dydx_values['operatingWithoutExploitSince'], time_list)
 
-  # Pulling and calculating Nuo data
-  nuo_tokens = [x['token'] for x in constants.nuoContractInfo]
-  nuo_balances = [pool_data_service.fetch_data_for_pool('nuo', t) for t in nuo_tokens]
-  nuo_portfolio_cvar = finance_service.generate_cvar_from_balances(nuo_balances)
-  # add instead of subtract here because cvar from this function is negative
-  constants.nuo_values['cvar'] = 1 + nuo_portfolio_cvar
+    # Pulling and calculating Fulcrum data
+    fulcrum_tokens = [x['token'] for x in constants.fulcrumContractInfo]
+    fulcrum_balances = [pool_data_service.fetch_data_for_pool('fulcrum', t) for t in fulcrum_tokens]
+    fulcrum_portfolio_cvar = finance_service.generate_cvar_from_balances(fulcrum_balances)
+    # add instead of subtract here because cvar from this function is negative
+    constants.fulcrum_values['cvar'] = 1 + fulcrum_portfolio_cvar
+    constants.fulcrum_values['timeIndex'] = finance_service.normalize_time_data(constants.fulcrum_values['operatingWithoutExploitSince'], time_list)
 
-  # Pulling and calculating DDEX data
-  ddex_tokens = [x['token'] for x in constants.ddexContractInfo]
-  ddex_balances = [pool_data_service.fetch_data_for_pool('ddex', t) for t in ddex_tokens]
-  ddex_portfolio_cvar = finance_service.generate_cvar_from_balances(ddex_balances)
-  # add instead of subtract here because cvar from this function is negative
-  constants.ddex_values['cvar'] = 1 + ddex_portfolio_cvar
+    # Pulling and calculating Nuo data
+    nuo_tokens = [x['token'] for x in constants.nuoContractInfo]
+    nuo_balances = [pool_data_service.fetch_data_for_pool('nuo', t) for t in nuo_tokens]
+    nuo_portfolio_cvar = finance_service.generate_cvar_from_balances(nuo_balances)
+    # add instead of subtract here because cvar from this function is negative
+    constants.nuo_values['cvar'] = 1 + nuo_portfolio_cvar
+    constants.nuo_values['timeIndex'] = finance_service.normalize_time_data(constants.nuo_values['operatingWithoutExploitSince'], time_list)
 
-  scores = calculate_scores()
+    # Pulling and calculating DDEX data
+    ddex_tokens = [x['token'] for x in constants.ddexContractInfo]
+    ddex_balances = [pool_data_service.fetch_data_for_pool('ddex', t) for t in ddex_tokens]
+    ddex_portfolio_cvar = finance_service.generate_cvar_from_balances(ddex_balances)
+    # add instead of subtract here because cvar from this function is negative
+    constants.ddex_values['cvar'] = 1 + ddex_portfolio_cvar
+    constants.ddex_values['timeIndex'] = finance_service.normalize_time_data(constants.ddex_values['operatingWithoutExploitSince'], time_list)
 
-  scores.append({
+    # Pulling and calculating AAVE data
+    aave_tokens = [x['token'] for x in constants.aaveContractInfo]
+    aave_balances = [pool_data_service.fetch_data_for_pool('aave', t) for t in aave_tokens]
+    aave_portfolio_cvar = finance_service.generate_cvar_from_balances(aave_balances)
+    # add instead of subtract here because cvar from this function is negative
+    constants.aave_values['cvar'] = 1 + aave_portfolio_cvar
+    constants.aave_values['timeIndex'] = finance_service.normalize_time_data(constants.aave_values['operatingWithoutExploitSince'], time_list)
+
+    scores = calculate_scores()
+
+    scores.append({
     'asset': 'dai',
     'protocol': 'mcd',
     'metrics': {
-      'score': 9.7
+        'score': 9.7
     }
-  })
+    })
 
-  with open('./implementation/data.json', 'w', encoding='utf-8') as f:
-      json.dump(scores, f, ensure_ascii=False, indent=4)
-  
-  print('Score calculation finished!')
+    with open('./implementation/data.json', 'w', encoding='utf-8') as f:
+        json.dump(scores, f, ensure_ascii=False, indent=4)
+
+    print('Score calculation finished!')
 
 main()

--- a/implementation/__main__.py
+++ b/implementation/__main__.py
@@ -17,7 +17,7 @@ def calculate_score(protocol, token, liquidity_value, collateral_value):
         protocol_values = constants.ddex_values
     
     weights = constants.weights
-    score = weights['engineeringWeeks'] * protocol_values['fourEngineeringWeeks'] + weights['noCriticalVulns'] * protocol_values['noCriticalVulns'] + weights['recentOrNoCodeChanges'] * protocol_values['recentAuditOrNoCodeChanges'] + weights['timeIndex'] * protocol_values['timeIndex'] + weights['hasBugBounty'] * protocol_values['hasBugBounty'] + weights['cVaR'] * protocol_values['cvar'] + weights['poolCollateralization'] * collateral_value + weights['poolLiquidity'] * liquidity_value + weights['centralizationRisk'] * protocol_values['centralizationRisk']
+    score = weights['engineeringWeeks'] * protocol_values['fourEngineeringWeeks'] + weights['publicAudit'] * protocol_values['publicAudit'] + weights['noCriticalVulns'] * protocol_values['noCriticalVulns'] + weights['recentOrNoCodeChanges'] * protocol_values['recentAuditOrNoCodeChanges'] + weights['timeIndex'] * protocol_values['timeIndex'] + weights['hasBugBounty'] * protocol_values['hasBugBounty'] + weights['cVaR'] * protocol_values['cvar'] + weights['poolCollateralization'] * collateral_value + weights['poolLiquidity'] * liquidity_value + weights['centralizationRisk'] * protocol_values['centralizationRisk']
     score = round(score, 2) * 10
     score = "{:.1f}".format(score)
     result = {
@@ -26,7 +26,8 @@ def calculate_score(protocol, token, liquidity_value, collateral_value):
         'metrics': {
             'score': score,
             'liquidityIndex': str(liquidity_value),
-            'collateralIndex': str(collateral_value)
+            'collateralIndex': str(collateral_value),
+            'centralizationIndex': str(protocol_values['centralizationRisk'])
         }
     }
     return result

--- a/implementation/constants.py
+++ b/implementation/constants.py
@@ -34,7 +34,7 @@ compound_values = {
  'operatingWithoutExploitSince': 1537926480,
  'publicAudit': 1,
  'hasBugBounty': 1,
- 'centralizationRisk': 0.375
+ 'centralizationRisk': 0.625
 }
 
 dydx_values = {

--- a/implementation/constants.py
+++ b/implementation/constants.py
@@ -12,12 +12,14 @@ nuo_kernel_address = '0xaf38668f4719ecf9452dc0300be3f6c83cbf3721'
 ddex_address = '0x241e82c79452f51fbfc89fac6d912e021db1a3b7'
 aave_address = '0x398eC7346DcD622eDc5ae82352F02bE94C62d119'
 
-# methodology based weights
+# Methodology based weights
 weights = {
-    'auditedCode': 0.25,
-    'allCodeOSS': 0.1,
-    'formalVer': 0.05,
-    'hasBugBounty': 0.05,
+    'engineeringWeeks': 0.045,
+    'noCriticalVulns': 0.09,
+    'recentOrNoCodeChanges': 0.0675,
+    'timeIndex': 0.1125,
+    'publicAudit': 0.0675,
+    'hasBugBounty': 0.0675,
     'cVaR': 0.1,
     'poolCollateralization': 0.1,
     'poolLiquidity': 0.1,
@@ -25,52 +27,63 @@ weights = {
 }
 
 # Setting values for off-chain data about protocols
-# If you find a mistake, please open an issue!
 compound_values = {
- 'isCodeAudited': 1,
- 'isCodeOpenSource': 1,
- 'isCodeFormallyVerified': 1,
+ 'fourEngineeringWeeks': 1,
+ 'noCriticalVulns': 1,
+ 'recentAuditOrNoCodeChanges': 1,
+ 'operatingWithoutExploitSince': 1537926480,
+ 'publicAudit': 1,
  'hasBugBounty': 1,
  'centralizationRisk': 0.375
 }
 
 dydx_values = {
- 'isCodeAudited': 1,
- 'isCodeOpenSource': 1,
- 'isCodeFormallyVerified': 0,
+ 'fourEngineeringWeeks': 1,
+ 'noCriticalVulns': 1,
+ 'recentAuditOrNoCodeChanges': 1,
+ 'operatingWithoutExploitSince': 1538001120,
+ 'publicAudit': 1,
  'hasBugBounty': 1,
  'centralizationRisk': 0.625
 }
 
 fulcrum_values = {
- 'isCodeAudited': 1,
- 'isCodeOpenSource': 1,
- 'isCodeFormallyVerified': 0,
+ 'fourEngineeringWeeks': 0,
+ 'noCriticalVulns': 0,
+ 'recentAuditOrNoCodeChanges': 0,
+ 'operatingWithoutExploitSince': 1581995638,
+ 'publicAudit': 1,
  'hasBugBounty': 1,
  'centralizationRisk': 0.5
 }
 
 nuo_values = {
  # This is marked as 0 because even though Nuo received a Quantstamp audit, they never released the audit report
- 'isCodeAudited': 0,
- 'isCodeOpenSource': 1,
- 'isCodeFormallyVerified': 0,
+ 'fourEngineeringWeeks': 0,
+ 'noCriticalVulns': 1,
+ 'recentAuditOrNoCodeChanges': 0,
+ 'operatingWithoutExploitSince': 1548172317,
+ 'publicAudit': 0,
  'hasBugBounty': 0,
  'centralizationRisk': 0.375
 }
 
 ddex_values = {
- 'isCodeAudited': 1,
- 'isCodeOpenSource': 1,
- 'isCodeFormallyVerified': 0,
+ 'fourEngineeringWeeks': 1,
+ 'noCriticalVulns': 1,
+ 'recentAuditOrNoCodeChanges': 0,
+ 'operatingWithoutExploitSince': 1566470505,
+ 'publicAudit': 1,
  'hasBugBounty': 1,
  'centralizationRisk': 0.5
 }
 
 aave_values = {
- 'isCodeAudited': 1,
- 'isCodeOpenSource': 1,
- 'isCodeFormallyVerified': 0,
+ 'fourEngineeringWeeks': 1,
+ 'noCriticalVulns': 1,
+ 'recentAuditOrNoCodeChanges': 1,
+ 'operatingWithoutExploitSince': 1578500586,
+ 'publicAudit': 1,
  'hasBugBounty': 1,
  'centralizationRisk': 0.5
 }

--- a/implementation/constants.py
+++ b/implementation/constants.py
@@ -58,7 +58,6 @@ fulcrum_values = {
 }
 
 nuo_values = {
- # This is marked as 0 because even though Nuo received a Quantstamp audit, they never released the audit report
  'fourEngineeringWeeks': 0,
  'noCriticalVulns': 1,
  'recentAuditOrNoCodeChanges': 0,
@@ -86,6 +85,16 @@ aave_values = {
  'publicAudit': 1,
  'hasBugBounty': 1,
  'centralizationRisk': 0.5
+}
+
+maker_values = {
+  'fourEngineeringWeeks': 1,
+  'noCriticalVulns': 1,
+  'recentAuditOrNoCodeChanges': 1,
+  'operatingWithoutExploitSince': 1513566600,
+  'publicAudit': 1,
+  'hasBugBounty': 1,
+  'centralizationRisk': 0.875
 }
 
 

--- a/implementation/data.json
+++ b/implementation/data.json
@@ -3,39 +3,43 @@
         "asset": "eth",
         "protocol": "dydx",
         "metrics": {
-            "score": "8.0",
-            "liquidityIndex": "0.8515637986837574",
-            "collateralIndex": "0.8172470696355405",
-            "timeIndex": "0.9984343659526111"
+            "score": "8.6",
+            "liquidityIndex": "0.8520755901596654",
+            "collateralIndex": "0.811408169438486",
+            "centralizationIndex": "0.625",
+            "timeIndex": "0.9984367185163403"
         }
     },
     {
         "asset": "usdc",
         "protocol": "dydx",
         "metrics": {
-            "score": "7.9",
-            "liquidityIndex": "0.8398466540259868",
-            "collateralIndex": "0.7511665922635182",
-            "timeIndex": "0.9984343659526111"
+            "score": "8.6",
+            "liquidityIndex": "0.841431688512537",
+            "collateralIndex": "0.7527558853088498",
+            "centralizationIndex": "0.625",
+            "timeIndex": "0.9984367185163403"
         }
     },
     {
         "asset": "dai",
         "protocol": "dydx",
         "metrics": {
-            "score": "7.5",
-            "liquidityIndex": "0.7469186380529538",
-            "collateralIndex": "0.41536770530175304",
-            "timeIndex": "0.9984343659526111"
+            "score": "8.2",
+            "liquidityIndex": "0.7472282630359302",
+            "collateralIndex": "0.4305178621781591",
+            "centralizationIndex": "0.625",
+            "timeIndex": "0.9984367185163403"
         }
     },
     {
         "asset": "eth",
         "protocol": "compound",
         "metrics": {
-            "score": "7.7",
+            "score": "9.0",
             "liquidityIndex": "1.0",
-            "collateralIndex": "0.993391407125494",
+            "collateralIndex": "0.9927101944636346",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -43,9 +47,10 @@
         "asset": "sai",
         "protocol": "compound",
         "metrics": {
-            "score": "6.9",
-            "liquidityIndex": "0.5672402791923424",
-            "collateralIndex": "0.6532754058070922",
+            "score": "8.2",
+            "liquidityIndex": "0.5650394531838304",
+            "collateralIndex": "0.6464173132679072",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -53,9 +58,10 @@
         "asset": "usdc",
         "protocol": "compound",
         "metrics": {
-            "score": "7.5",
-            "liquidityIndex": "0.9798191242384099",
-            "collateralIndex": "0.8532753423199332",
+            "score": "8.8",
+            "liquidityIndex": "0.9768152521354482",
+            "collateralIndex": "0.848421270117523",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -63,9 +69,10 @@
         "asset": "zrx",
         "protocol": "compound",
         "metrics": {
-            "score": "7.2",
-            "liquidityIndex": "0.5923072932813367",
-            "collateralIndex": "0.9827458445281878",
+            "score": "8.5",
+            "liquidityIndex": "0.5920818512114687",
+            "collateralIndex": "0.9824689342222503",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -73,9 +80,10 @@
         "asset": "bat",
         "protocol": "compound",
         "metrics": {
-            "score": "7.2",
-            "liquidityIndex": "0.5905154185704402",
-            "collateralIndex": "0.9393104641216498",
+            "score": "8.5",
+            "liquidityIndex": "0.5899997337175562",
+            "collateralIndex": "0.9384083800794932",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -83,9 +91,10 @@
         "asset": "rep",
         "protocol": "compound",
         "metrics": {
-            "score": "7.4",
-            "liquidityIndex": "0.7378019466903512",
-            "collateralIndex": "0.9786880604705332",
+            "score": "8.7",
+            "liquidityIndex": "0.7426501182031616",
+            "collateralIndex": "0.9782928612515862",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -93,9 +102,10 @@
         "asset": "wbtc",
         "protocol": "compound",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.6538475785895267",
-            "collateralIndex": "0.9714398314133521",
+            "score": "8.6",
+            "liquidityIndex": "0.6555833791685883",
+            "collateralIndex": "0.970265875899263",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -103,9 +113,10 @@
         "asset": "dai",
         "protocol": "compound",
         "metrics": {
-            "score": "6.9",
-            "liquidityIndex": "0.8817200516277388",
-            "collateralIndex": "0.36056248224927234",
+            "score": "8.2",
+            "liquidityIndex": "0.8840091571784946",
+            "collateralIndex": "0.3615055453190418",
+            "centralizationIndex": "0.625",
             "timeIndex": "1.0"
         }
     },
@@ -113,90 +124,99 @@
         "asset": "sai",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.4013016803740785",
-            "collateralIndex": "0.7791399290781891",
-            "timeIndex": "0.07561422905865445"
+            "score": "4.8",
+            "liquidityIndex": "0.4021140637029445",
+            "collateralIndex": "0.7794570490671833",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "eth",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "3.4",
-            "liquidityIndex": "0.4394744513102643",
+            "score": "4.1",
+            "liquidityIndex": "0.4566764151423366",
             "collateralIndex": "0.0",
-            "timeIndex": "0.07561422905865445"
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "usdc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.4",
-            "liquidityIndex": "0.5377249874802286",
-            "collateralIndex": "0.8877329040301913",
-            "timeIndex": "0.07561422905865445"
+            "score": "5.1",
+            "liquidityIndex": "0.5220189262988152",
+            "collateralIndex": "0.8695271125168879",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.33839873687473493",
-            "collateralIndex": "0.8564345539203175",
-            "timeIndex": "0.07561422905865445"
+            "score": "4.9",
+            "liquidityIndex": "0.3403461918620396",
+            "collateralIndex": "0.8543606323278827",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "link",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.3",
-            "liquidityIndex": "0.301708662695177",
+            "score": "5.0",
+            "liquidityIndex": "0.3021446951402659",
             "collateralIndex": "1.0",
-            "timeIndex": "0.07561422905865445"
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "zrx",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.1",
-            "liquidityIndex": "0.1181657926458819",
+            "score": "4.8",
+            "liquidityIndex": "0.11806636698448043",
             "collateralIndex": "1.0",
-            "timeIndex": "0.07561422905865445"
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "knc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.18747124869640713",
+            "score": "4.8",
+            "liquidityIndex": "0.18787173195430937",
             "collateralIndex": "1.0",
-            "timeIndex": "0.07561422905865445"
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "dai",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.4",
-            "liquidityIndex": "0.6405206314293734",
-            "collateralIndex": "0.7418106292835562",
-            "timeIndex": "0.07561422905865445"
+            "score": "5.0",
+            "liquidityIndex": "0.6337332804181918",
+            "collateralIndex": "0.7262548354223962",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
         "asset": "susd",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.0",
+            "score": "4.7",
             "liquidityIndex": "0.0",
             "collateralIndex": "1.0",
-            "timeIndex": "0.07561422905865445"
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.07700317751968233"
         }
     },
     {
@@ -204,9 +224,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "5.0",
-            "liquidityIndex": "0.3591455827211757",
-            "collateralIndex": "0.9641151570215092",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.3579321941610498",
+            "collateralIndex": "0.9635959496013854",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -214,9 +235,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "5.1",
-            "liquidityIndex": "0.500195622764581",
-            "collateralIndex": "0.9800844213767133",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.5008614803505287",
+            "collateralIndex": "0.9832052734908261",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -224,9 +246,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "5.2",
-            "liquidityIndex": "0.6022016797263983",
-            "collateralIndex": "0.9281193666782575",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.5918122572327811",
+            "collateralIndex": "0.9062613793575294",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -234,9 +257,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.9",
-            "liquidityIndex": "0.37875550410017317",
-            "collateralIndex": "0.8299217965356218",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.3814632223797146",
+            "collateralIndex": "0.8345485129003045",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -244,9 +268,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.8",
-            "liquidityIndex": "0.15878227326997205",
+            "liquidityIndex": "0.1636105965131883",
             "collateralIndex": "1.0",
-            "timeIndex": "0.7850855200607274"
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -254,9 +279,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.9",
-            "liquidityIndex": "0.29020428184926017",
-            "collateralIndex": "0.9542043391908062",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.29063978555013065",
+            "collateralIndex": "0.9535417350123273",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -264,9 +290,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "5.0",
-            "liquidityIndex": "0.3619962744415894",
-            "collateralIndex": "0.9817101137955135",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.3621037535963098",
+            "collateralIndex": "0.9776392918558805",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -274,9 +301,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.9",
-            "liquidityIndex": "0.22722757821294579",
+            "liquidityIndex": "0.22416596357389193",
             "collateralIndex": "1.0",
-            "timeIndex": "0.7850855200607274"
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -284,19 +312,21 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.8",
-            "liquidityIndex": "0.1729525577651577",
+            "liquidityIndex": "0.17218239236625751",
             "collateralIndex": "1.0",
-            "timeIndex": "0.7850855200607274"
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
         "asset": "bat",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.9",
-            "liquidityIndex": "0.2510524129421067",
-            "collateralIndex": "0.9603214017827858",
-            "timeIndex": "0.7850855200607274"
+            "score": "4.8",
+            "liquidityIndex": "0.23679658936993067",
+            "collateralIndex": "0.9297487017569416",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -304,9 +334,10 @@
         "protocol": "nuo",
         "metrics": {
             "score": "4.2",
-            "liquidityIndex": "0.1616439484644266",
-            "collateralIndex": "0.3364865175149261",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.16410857824271097",
+            "collateralIndex": "0.3281512510983864",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
@@ -314,209 +345,230 @@
         "protocol": "nuo",
         "metrics": {
             "score": "5.1",
-            "liquidityIndex": "0.48400769844273045",
-            "collateralIndex": "0.9308511111705482",
-            "timeIndex": "0.7850855200607274"
+            "liquidityIndex": "0.4858430489799217",
+            "collateralIndex": "0.9318131300678324",
+            "centralizationIndex": "0.375",
+            "timeIndex": "0.7854084335617837"
         }
     },
     {
         "asset": "sai",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.0",
-            "liquidityIndex": "0.2735995350876018",
+            "score": "6.6",
+            "liquidityIndex": "0.27247750769485823",
             "collateralIndex": "1.0",
-            "timeIndex": "0.40126680288478234"
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.4021663617251423"
         }
     },
     {
         "asset": "eth",
         "protocol": "ddex",
         "metrics": {
-            "score": "5.5",
-            "liquidityIndex": "0.4541133885342506",
-            "collateralIndex": "0.38973788698425027",
-            "timeIndex": "0.40126680288478234"
+            "score": "6.2",
+            "liquidityIndex": "0.45432574767592354",
+            "collateralIndex": "0.38068726879893733",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.4021663617251423"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "ddex",
         "metrics": {
-            "score": "5.0",
-            "liquidityIndex": "0.0803073647534594",
-            "collateralIndex": "0.25243229878709694",
-            "timeIndex": "0.40126680288478234"
+            "score": "5.7",
+            "liquidityIndex": "0.09901193219446873",
+            "collateralIndex": "0.21067141820484414",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.4021663617251423"
         }
     },
     {
         "asset": "dai",
         "protocol": "ddex",
         "metrics": {
-            "score": "5.3",
-            "liquidityIndex": "0.11711964209013104",
-            "collateralIndex": "0.4462543222234613",
-            "timeIndex": "0.40126680288478234"
+            "score": "6.1",
+            "liquidityIndex": "0.15814578670522708",
+            "collateralIndex": "0.5560521108971219",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.4021663617251423"
         }
     },
     {
         "asset": "usdt",
         "protocol": "ddex",
         "metrics": {
-            "score": "5.7",
-            "liquidityIndex": "0.5756819411744439",
-            "collateralIndex": "0.3807064055676237",
-            "timeIndex": "0.40126680288478234"
+            "score": "6.3",
+            "liquidityIndex": "0.5780153043196772",
+            "collateralIndex": "0.380793433838743",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.4021663617251423"
         }
     },
     {
         "asset": "usdc",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.1",
-            "liquidityIndex": "0.5011890074242966",
-            "collateralIndex": "0.9247699925876371",
-            "timeIndex": "0.40126680288478234"
+            "score": "6.8",
+            "liquidityIndex": "0.4994467681391346",
+            "collateralIndex": "0.9140722138588073",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.4021663617251423"
         }
     },
     {
         "asset": "eth",
         "protocol": "aave",
         "metrics": {
-            "score": "6.7",
-            "liquidityIndex": "0.7711534579432506",
-            "collateralIndex": "0.956189295597801",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.4",
+            "liquidityIndex": "0.7716519161917134",
+            "collateralIndex": "0.9574367623205171",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "usdc",
         "protocol": "aave",
         "metrics": {
-            "score": "6.2",
-            "liquidityIndex": "0.7329874675437803",
-            "collateralIndex": "0.4471238541978182",
-            "timeIndex": "0.14892685964837105"
+            "score": "6.8",
+            "liquidityIndex": "0.72170318413529",
+            "collateralIndex": "0.4096147425504254",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "aave",
         "metrics": {
-            "score": "6.5",
-            "liquidityIndex": "0.55091147702357",
-            "collateralIndex": "0.9307382100514614",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.1",
+            "liquidityIndex": "0.5487767135637603",
+            "collateralIndex": "0.9269030795702533",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "link",
         "protocol": "aave",
         "metrics": {
-            "score": "6.8",
-            "liquidityIndex": "0.8729191556490385",
-            "collateralIndex": "0.993143456864787",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.5",
+            "liquidityIndex": "0.8734437375083866",
+            "collateralIndex": "0.9930486734524866",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "zrx",
         "protocol": "aave",
         "metrics": {
-            "score": "6.4",
-            "liquidityIndex": "0.40284728287616167",
-            "collateralIndex": "0.9728872159500537",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.0",
+            "liquidityIndex": "0.40323884516675507",
+            "collateralIndex": "0.9715500223923547",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "knc",
         "protocol": "aave",
         "metrics": {
-            "score": "6.6",
-            "liquidityIndex": "0.6453386291258326",
-            "collateralIndex": "0.9482715616960512",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.2",
+            "liquidityIndex": "0.6456657752554745",
+            "collateralIndex": "0.9467280114809613",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "dai",
         "protocol": "aave",
         "metrics": {
-            "score": "6.0",
-            "liquidityIndex": "0.5543368195712035",
-            "collateralIndex": "0.42108958335941105",
-            "timeIndex": "0.14892685964837105"
+            "score": "6.6",
+            "liquidityIndex": "0.5570553854340169",
+            "collateralIndex": "0.40761489164197495",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "bat",
         "protocol": "aave",
         "metrics": {
-            "score": "6.3",
-            "liquidityIndex": "0.462781830521867",
-            "collateralIndex": "0.887393569839915",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.0",
+            "liquidityIndex": "0.4620204303913698",
+            "collateralIndex": "0.8856472760458898",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "lend",
         "protocol": "aave",
         "metrics": {
-            "score": "6.8",
-            "liquidityIndex": "0.802089785443487",
-            "collateralIndex": "0.9986660974859555",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.5",
+            "liquidityIndex": "0.8005521004466557",
+            "collateralIndex": "0.9986460958278516",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "mkr",
         "protocol": "aave",
         "metrics": {
-            "score": "6.4",
-            "liquidityIndex": "0.45746508531740304",
-            "collateralIndex": "0.9686467721333125",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.1",
+            "liquidityIndex": "0.45043063788514254",
+            "collateralIndex": "0.9670660947640128",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "tusd",
         "protocol": "aave",
         "metrics": {
-            "score": "6.3",
-            "liquidityIndex": "0.6924054721529364",
-            "collateralIndex": "0.6661686387736898",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.1",
+            "liquidityIndex": "0.7069991831891334",
+            "collateralIndex": "0.6973600631579164",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "usdt",
         "protocol": "aave",
         "metrics": {
-            "score": "5.9",
-            "liquidityIndex": "0.673637858238819",
-            "collateralIndex": "0.29507518583853454",
-            "timeIndex": "0.14892685964837105"
+            "score": "6.6",
+            "liquidityIndex": "0.6764392394064354",
+            "collateralIndex": "0.2945026191448157",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "snx",
         "protocol": "aave",
         "metrics": {
-            "score": "5.7",
-            "liquidityIndex": "0.34855942572980064",
-            "collateralIndex": "0.34585802624491246",
-            "timeIndex": "0.14892685964837105"
+            "score": "6.4",
+            "liquidityIndex": "0.35422898893645227",
+            "collateralIndex": "0.34632922025000823",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {
         "asset": "susd",
         "protocol": "aave",
         "metrics": {
-            "score": "6.5",
-            "liquidityIndex": "0.6730634659270887",
-            "collateralIndex": "0.8058098471388426",
-            "timeIndex": "0.14892685964837105"
+            "score": "7.1",
+            "liquidityIndex": "0.6683212948077015",
+            "collateralIndex": "0.7598741956838113",
+            "centralizationIndex": "0.5",
+            "timeIndex": "0.15020550714150982"
         }
     },
     {

--- a/implementation/data.json
+++ b/implementation/data.json
@@ -3,121 +3,121 @@
         "asset": "eth",
         "protocol": "dydx",
         "metrics": {
-            "score": "8.6",
-            "liquidityIndex": "0.8520755901596654",
-            "collateralIndex": "0.811408169438486",
+            "score": "8.3",
+            "liquidityIndex": "0.8536376859523823",
+            "collateralIndex": "0.8153716297181168",
             "centralizationIndex": "0.625",
-            "timeIndex": "0.9984367185163403"
+            "timIndex": "0.6615137055356584"
         }
     },
     {
         "asset": "usdc",
         "protocol": "dydx",
         "metrics": {
-            "score": "8.6",
-            "liquidityIndex": "0.841431688512537",
-            "collateralIndex": "0.7527558853088498",
+            "score": "8.2",
+            "liquidityIndex": "0.8372105751635339",
+            "collateralIndex": "0.7525858324120588",
             "centralizationIndex": "0.625",
-            "timeIndex": "0.9984367185163403"
+            "timIndex": "0.6615137055356584"
         }
     },
     {
         "asset": "dai",
         "protocol": "dydx",
         "metrics": {
-            "score": "8.2",
-            "liquidityIndex": "0.7472282630359302",
-            "collateralIndex": "0.4305178621781591",
+            "score": "7.8",
+            "liquidityIndex": "0.7474680642953901",
+            "collateralIndex": "0.44757893291354667",
             "centralizationIndex": "0.625",
-            "timeIndex": "0.9984367185163403"
+            "timIndex": "0.6615137055356584"
         }
     },
     {
         "asset": "eth",
         "protocol": "compound",
         "metrics": {
-            "score": "9.0",
+            "score": "8.6",
             "liquidityIndex": "1.0",
-            "collateralIndex": "0.9927101944636346",
+            "collateralIndex": "0.9929986715524295",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "sai",
         "protocol": "compound",
         "metrics": {
-            "score": "8.2",
-            "liquidityIndex": "0.5650394531838304",
-            "collateralIndex": "0.6464173132679072",
+            "score": "7.8",
+            "liquidityIndex": "0.5660099783597532",
+            "collateralIndex": "0.6561247155157436",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "usdc",
         "protocol": "compound",
         "metrics": {
-            "score": "8.8",
-            "liquidityIndex": "0.9768152521354482",
-            "collateralIndex": "0.848421270117523",
+            "score": "8.4",
+            "liquidityIndex": "0.9767476497232541",
+            "collateralIndex": "0.851690518310501",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "zrx",
         "protocol": "compound",
         "metrics": {
-            "score": "8.5",
-            "liquidityIndex": "0.5920818512114687",
-            "collateralIndex": "0.9824689342222503",
+            "score": "8.2",
+            "liquidityIndex": "0.5921234312389594",
+            "collateralIndex": "0.9829639246909666",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "bat",
         "protocol": "compound",
         "metrics": {
-            "score": "8.5",
-            "liquidityIndex": "0.5899997337175562",
-            "collateralIndex": "0.9384083800794932",
+            "score": "8.1",
+            "liquidityIndex": "0.5902757884641426",
+            "collateralIndex": "0.9400384156886809",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "rep",
         "protocol": "compound",
         "metrics": {
-            "score": "8.7",
-            "liquidityIndex": "0.7426501182031616",
-            "collateralIndex": "0.9782928612515862",
+            "score": "8.3",
+            "liquidityIndex": "0.7398845400438491",
+            "collateralIndex": "0.9790595366196335",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "compound",
         "metrics": {
-            "score": "8.6",
-            "liquidityIndex": "0.6555833791685883",
-            "collateralIndex": "0.970265875899263",
+            "score": "8.2",
+            "liquidityIndex": "0.6542474770613463",
+            "collateralIndex": "0.9716603417679766",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
         "asset": "dai",
         "protocol": "compound",
         "metrics": {
-            "score": "8.2",
-            "liquidityIndex": "0.8840091571784946",
-            "collateralIndex": "0.3615055453190418",
+            "score": "7.9",
+            "liquidityIndex": "0.8894170786306212",
+            "collateralIndex": "0.3980283086033287",
             "centralizationIndex": "0.625",
-            "timeIndex": "1.0"
+            "timIndex": "0.662547645120223"
         }
     },
     {
@@ -125,10 +125,10 @@
         "protocol": "fulcrum",
         "metrics": {
             "score": "4.8",
-            "liquidityIndex": "0.4021140637029445",
-            "collateralIndex": "0.7794570490671833",
+            "liquidityIndex": "0.4047591156313319",
+            "collateralIndex": "0.7879006169368703",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
@@ -136,54 +136,54 @@
         "protocol": "fulcrum",
         "metrics": {
             "score": "4.1",
-            "liquidityIndex": "0.4566764151423366",
+            "liquidityIndex": "0.42064064421264713",
             "collateralIndex": "0.0",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "usdc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "5.1",
-            "liquidityIndex": "0.5220189262988152",
-            "collateralIndex": "0.8695271125168879",
+            "score": "5.0",
+            "liquidityIndex": "0.5212489591326457",
+            "collateralIndex": "0.8711284304075796",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.9",
-            "liquidityIndex": "0.3403461918620396",
-            "collateralIndex": "0.8543606323278827",
+            "score": "4.8",
+            "liquidityIndex": "0.33967319329390566",
+            "collateralIndex": "0.8586239519315774",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "link",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "5.0",
-            "liquidityIndex": "0.3021446951402659",
+            "score": "4.9",
+            "liquidityIndex": "0.3074093623966271",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "zrx",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.8",
-            "liquidityIndex": "0.11806636698448043",
+            "score": "4.7",
+            "liquidityIndex": "0.11905648637422281",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
@@ -191,186 +191,186 @@
         "protocol": "fulcrum",
         "metrics": {
             "score": "4.8",
-            "liquidityIndex": "0.18787173195430937",
+            "liquidityIndex": "0.18763799674570025",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "dai",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "5.0",
-            "liquidityIndex": "0.6337332804181918",
-            "collateralIndex": "0.7262548354223962",
+            "score": "4.6",
+            "liquidityIndex": "0.5784599803805289",
+            "collateralIndex": "0.3821066164285394",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "susd",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "4.7",
+            "score": "4.6",
             "liquidityIndex": "0.0",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.07700317751968233"
+            "timIndex": "0.052066994690544655"
         }
     },
     {
         "asset": "sai",
         "protocol": "nuo",
         "metrics": {
-            "score": "5.0",
-            "liquidityIndex": "0.3579321941610498",
-            "collateralIndex": "0.9635959496013854",
+            "score": "4.7",
+            "liquidityIndex": "0.36016129338742997",
+            "collateralIndex": "0.9678163869444392",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "eth",
         "protocol": "nuo",
         "metrics": {
-            "score": "5.1",
-            "liquidityIndex": "0.5008614803505287",
-            "collateralIndex": "0.9832052734908261",
+            "score": "4.9",
+            "liquidityIndex": "0.5022352729188361",
+            "collateralIndex": "0.9894092206681262",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "usdc",
         "protocol": "nuo",
         "metrics": {
-            "score": "5.2",
-            "liquidityIndex": "0.5918122572327811",
-            "collateralIndex": "0.9062613793575294",
+            "score": "4.9",
+            "liquidityIndex": "0.5888475937408361",
+            "collateralIndex": "0.9006196595977427",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.9",
-            "liquidityIndex": "0.3814632223797146",
-            "collateralIndex": "0.8345485129003045",
+            "score": "4.6",
+            "liquidityIndex": "0.3827868716338962",
+            "collateralIndex": "0.8599107628619131",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "rep",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.8",
-            "liquidityIndex": "0.1636105965131883",
+            "score": "4.5",
+            "liquidityIndex": "0.16211707845392084",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "link",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.9",
-            "liquidityIndex": "0.29063978555013065",
-            "collateralIndex": "0.9535417350123273",
+            "score": "4.6",
+            "liquidityIndex": "0.29485491955779297",
+            "collateralIndex": "0.9543766721571783",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "knc",
         "protocol": "nuo",
         "metrics": {
-            "score": "5.0",
-            "liquidityIndex": "0.3621037535963098",
-            "collateralIndex": "0.9776392918558805",
+            "score": "4.7",
+            "liquidityIndex": "0.36152279603827775",
+            "collateralIndex": "0.9782720363492211",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "mkr",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.9",
-            "liquidityIndex": "0.22416596357389193",
+            "score": "4.6",
+            "liquidityIndex": "0.2285542287839667",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "tusd",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.8",
-            "liquidityIndex": "0.17218239236625751",
-            "collateralIndex": "1.0",
+            "score": "4.4",
+            "liquidityIndex": "0.15919554236649539",
+            "collateralIndex": "0.8606464347718361",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "bat",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.8",
-            "liquidityIndex": "0.23679658936993067",
-            "collateralIndex": "0.9297487017569416",
+            "score": "4.6",
+            "liquidityIndex": "0.24051182956224895",
+            "collateralIndex": "0.9563789296734856",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "snx",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.16410857824271097",
-            "collateralIndex": "0.3281512510983864",
+            "score": "3.8",
+            "liquidityIndex": "0.16548750692912897",
+            "collateralIndex": "0.3066805889372165",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "dai",
         "protocol": "nuo",
         "metrics": {
-            "score": "5.1",
-            "liquidityIndex": "0.4858430489799217",
-            "collateralIndex": "0.9318131300678324",
+            "score": "4.8",
+            "liquidityIndex": "0.4789376034536045",
+            "collateralIndex": "0.9293976481177855",
             "centralizationIndex": "0.375",
-            "timeIndex": "0.7854084335617837"
+            "timIndex": "0.5206145199715708"
         }
     },
     {
         "asset": "sai",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.6",
-            "liquidityIndex": "0.27247750769485823",
+            "score": "6.5",
+            "liquidityIndex": "0.2741265568449466",
             "collateralIndex": "1.0",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.4021663617251423"
+            "timIndex": "0.26713379813661253"
         }
     },
     {
         "asset": "eth",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.2",
-            "liquidityIndex": "0.45432574767592354",
-            "collateralIndex": "0.38068726879893733",
+            "score": "6.0",
+            "liquidityIndex": "0.4634885536654151",
+            "collateralIndex": "0.34217765249529264",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.4021663617251423"
+            "timIndex": "0.26713379813661253"
         }
     },
     {
@@ -378,54 +378,54 @@
         "protocol": "ddex",
         "metrics": {
             "score": "5.7",
-            "liquidityIndex": "0.09901193219446873",
-            "collateralIndex": "0.21067141820484414",
+            "liquidityIndex": "0.17857784622020142",
+            "collateralIndex": "0.34824760267960964",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.4021663617251423"
+            "timIndex": "0.26713379813661253"
         }
     },
     {
         "asset": "dai",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.1",
-            "liquidityIndex": "0.15814578670522708",
-            "collateralIndex": "0.5560521108971219",
+            "score": "6.0",
+            "liquidityIndex": "0.1621998072285898",
+            "collateralIndex": "0.5743210439474737",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.4021663617251423"
+            "timIndex": "0.26713379813661253"
         }
     },
     {
         "asset": "usdt",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.3",
-            "liquidityIndex": "0.5780153043196772",
-            "collateralIndex": "0.380793433838743",
+            "score": "6.2",
+            "liquidityIndex": "0.5850067898747172",
+            "collateralIndex": "0.434778974558916",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.4021663617251423"
+            "timIndex": "0.26713379813661253"
         }
     },
     {
         "asset": "usdc",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.8",
-            "liquidityIndex": "0.4994467681391346",
-            "collateralIndex": "0.9140722138588073",
+            "score": "6.6",
+            "liquidityIndex": "0.4998351593502496",
+            "collateralIndex": "0.9095135120675815",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.4021663617251423"
+            "timIndex": "0.26713379813661253"
         }
     },
     {
         "asset": "eth",
         "protocol": "aave",
         "metrics": {
-            "score": "7.4",
-            "liquidityIndex": "0.7716519161917134",
-            "collateralIndex": "0.9574367623205171",
+            "score": "7.3",
+            "liquidityIndex": "0.7577354744595192",
+            "collateralIndex": "0.9519772910157602",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -433,10 +433,10 @@
         "protocol": "aave",
         "metrics": {
             "score": "6.8",
-            "liquidityIndex": "0.72170318413529",
-            "collateralIndex": "0.4096147425504254",
+            "liquidityIndex": "0.7259005925850418",
+            "collateralIndex": "0.4355502764733753",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -444,10 +444,10 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.1",
-            "liquidityIndex": "0.5487767135637603",
-            "collateralIndex": "0.9269030795702533",
+            "liquidityIndex": "0.5476559565621638",
+            "collateralIndex": "0.929026620822791",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -455,10 +455,10 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.5",
-            "liquidityIndex": "0.8734437375083866",
-            "collateralIndex": "0.9930486734524866",
+            "liquidityIndex": "0.8775255142336151",
+            "collateralIndex": "0.9926736927119799",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -466,10 +466,10 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.0",
-            "liquidityIndex": "0.40323884516675507",
-            "collateralIndex": "0.9715500223923547",
+            "liquidityIndex": "0.40366065192985157",
+            "collateralIndex": "0.9723550759063524",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -477,10 +477,10 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.2",
-            "liquidityIndex": "0.6456657752554745",
-            "collateralIndex": "0.9467280114809613",
+            "liquidityIndex": "0.6364277855091525",
+            "collateralIndex": "0.9481483206119586",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -488,10 +488,10 @@
         "protocol": "aave",
         "metrics": {
             "score": "6.6",
-            "liquidityIndex": "0.5570553854340169",
-            "collateralIndex": "0.40761489164197495",
+            "liquidityIndex": "0.5586295438535301",
+            "collateralIndex": "0.42658062359741056",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -499,43 +499,43 @@
         "protocol": "aave",
         "metrics": {
             "score": "7.0",
-            "liquidityIndex": "0.4620204303913698",
-            "collateralIndex": "0.8856472760458898",
+            "liquidityIndex": "0.4627338244330142",
+            "collateralIndex": "0.8888831338544515",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
         "asset": "lend",
         "protocol": "aave",
         "metrics": {
-            "score": "7.5",
-            "liquidityIndex": "0.8005521004466557",
-            "collateralIndex": "0.9986460958278516",
+            "score": "7.4",
+            "liquidityIndex": "0.7998759277366383",
+            "collateralIndex": "0.9986856516439802",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
         "asset": "mkr",
         "protocol": "aave",
         "metrics": {
-            "score": "7.1",
-            "liquidityIndex": "0.45043063788514254",
-            "collateralIndex": "0.9670660947640128",
+            "score": "7.0",
+            "liquidityIndex": "0.45185513334638594",
+            "collateralIndex": "0.968771499059943",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
         "asset": "tusd",
         "protocol": "aave",
         "metrics": {
-            "score": "7.1",
-            "liquidityIndex": "0.7069991831891334",
-            "collateralIndex": "0.6973600631579164",
+            "score": "7.0",
+            "liquidityIndex": "0.7068458424563931",
+            "collateralIndex": "0.7062820885750666",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
@@ -543,39 +543,41 @@
         "protocol": "aave",
         "metrics": {
             "score": "6.6",
-            "liquidityIndex": "0.6764392394064354",
-            "collateralIndex": "0.2945026191448157",
+            "liquidityIndex": "0.6769087213692342",
+            "collateralIndex": "0.3135215892897274",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
         "asset": "snx",
         "protocol": "aave",
         "metrics": {
-            "score": "6.4",
-            "liquidityIndex": "0.35422898893645227",
-            "collateralIndex": "0.34632922025000823",
+            "score": "6.1",
+            "liquidityIndex": "0.2925202862107055",
+            "collateralIndex": "0.1583235149387553",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
         "asset": "susd",
         "protocol": "aave",
         "metrics": {
-            "score": "7.1",
-            "liquidityIndex": "0.6683212948077015",
-            "collateralIndex": "0.7598741956838113",
+            "score": "7.0",
+            "liquidityIndex": "0.6689679832628296",
+            "collateralIndex": "0.7706774428280864",
             "centralizationIndex": "0.5",
-            "timeIndex": "0.15020550714150982"
+            "timIndex": "0.10048397169977397"
         }
     },
     {
         "asset": "dai",
         "protocol": "mcd",
         "metrics": {
-            "score": 9.7
+            "score": "9.7",
+            "timeIndex": "1",
+            "centralizationIndex": "0.875"
         }
     }
 ]

--- a/implementation/data.json
+++ b/implementation/data.json
@@ -3,477 +3,527 @@
         "asset": "eth",
         "protocol": "dydx",
         "metrics": {
-            "score": "8.2",
-            "liquidityIndex": "0.8592376902313974",
-            "collateralIndex": "0.9347612497162907"
+            "score": "8.0",
+            "liquidityIndex": "0.8515637986837574",
+            "collateralIndex": "0.8172470696355405",
+            "timeIndex": "0.9984343659526111"
         }
     },
     {
         "asset": "usdc",
         "protocol": "dydx",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.5442535948703474",
-            "collateralIndex": "0.0"
+            "score": "7.9",
+            "liquidityIndex": "0.8398466540259868",
+            "collateralIndex": "0.7511665922635182",
+            "timeIndex": "0.9984343659526111"
         }
     },
     {
         "asset": "dai",
         "protocol": "dydx",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.5370310412405006",
-            "collateralIndex": "0.09175070545080455"
+            "score": "7.5",
+            "liquidityIndex": "0.7469186380529538",
+            "collateralIndex": "0.41536770530175304",
+            "timeIndex": "0.9984343659526111"
         }
     },
     {
         "asset": "eth",
         "protocol": "compound",
         "metrics": {
-            "score": "8.3",
+            "score": "7.7",
             "liquidityIndex": "1.0",
-            "collateralIndex": "0.9892226226042078"
+            "collateralIndex": "0.993391407125494",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "sai",
         "protocol": "compound",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.6863142502986896",
-            "collateralIndex": "0.584941044702947"
+            "score": "6.9",
+            "liquidityIndex": "0.5672402791923424",
+            "collateralIndex": "0.6532754058070922",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "usdc",
         "protocol": "compound",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.8582851302878575",
-            "collateralIndex": "0.41744973907681004"
+            "score": "7.5",
+            "liquidityIndex": "0.9798191242384099",
+            "collateralIndex": "0.8532753423199332",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "zrx",
         "protocol": "compound",
         "metrics": {
-            "score": "7.9",
-            "liquidityIndex": "0.6065727267896296",
-            "collateralIndex": "0.9284229546345295"
+            "score": "7.2",
+            "liquidityIndex": "0.5923072932813367",
+            "collateralIndex": "0.9827458445281878",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "bat",
         "protocol": "compound",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.5710974315134446",
-            "collateralIndex": "0.9094650579450917"
+            "score": "7.2",
+            "liquidityIndex": "0.5905154185704402",
+            "collateralIndex": "0.9393104641216498",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "rep",
         "protocol": "compound",
         "metrics": {
-            "score": "8.2",
-            "liquidityIndex": "0.8827832014847731",
-            "collateralIndex": "0.9941791901200796"
+            "score": "7.4",
+            "liquidityIndex": "0.7378019466903512",
+            "collateralIndex": "0.9786880604705332",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "compound",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.6055861863097011",
-            "collateralIndex": "0.8525629869537762"
+            "score": "7.3",
+            "liquidityIndex": "0.6538475785895267",
+            "collateralIndex": "0.9714398314133521",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "dai",
         "protocol": "compound",
         "metrics": {
-            "score": "7.2",
-            "liquidityIndex": "0.7491336418915462",
-            "collateralIndex": "0.15677298513598492"
-        }
-    },
-    {
-        "asset": "dai",
-        "protocol": "fulcrum",
-        "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.6697236038782413",
-            "collateralIndex": "0.5754508726592501"
+            "score": "6.9",
+            "liquidityIndex": "0.8817200516277388",
+            "collateralIndex": "0.36056248224927234",
+            "timeIndex": "1.0"
         }
     },
     {
         "asset": "sai",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.4752138675698243",
-            "collateralIndex": "0.6218316171516947"
+            "score": "4.2",
+            "liquidityIndex": "0.4013016803740785",
+            "collateralIndex": "0.7791399290781891",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "eth",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "8.0",
-            "liquidityIndex": "0.5541063059671661",
-            "collateralIndex": "0.9742257633161726"
+            "score": "3.4",
+            "liquidityIndex": "0.4394744513102643",
+            "collateralIndex": "0.0",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "usdc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.34491372014941385",
-            "collateralIndex": "0.08733426468407957"
+            "score": "4.4",
+            "liquidityIndex": "0.5377249874802286",
+            "collateralIndex": "0.8877329040301913",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.43177096570802626",
-            "collateralIndex": "0.8666254532492241"
+            "score": "4.2",
+            "liquidityIndex": "0.33839873687473493",
+            "collateralIndex": "0.8564345539203175",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "link",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.2985942344139382",
-            "collateralIndex": "0.99993864831974"
+            "score": "4.3",
+            "liquidityIndex": "0.301708662695177",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "zrx",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.14682453474508728",
-            "collateralIndex": "0.9227246565795725"
+            "score": "4.1",
+            "liquidityIndex": "0.1181657926458819",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "knc",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.9",
-            "liquidityIndex": "0.3493270238982441",
-            "collateralIndex": "0.9976925605818618"
+            "score": "4.2",
+            "liquidityIndex": "0.18747124869640713",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.07561422905865445"
+        }
+    },
+    {
+        "asset": "dai",
+        "protocol": "fulcrum",
+        "metrics": {
+            "score": "4.4",
+            "liquidityIndex": "0.6405206314293734",
+            "collateralIndex": "0.7418106292835562",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "susd",
         "protocol": "fulcrum",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.25484397863449193",
-            "collateralIndex": "0.4931036294596718"
+            "score": "4.0",
+            "liquidityIndex": "0.0",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.07561422905865445"
         }
     },
     {
         "asset": "sai",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.0",
-            "liquidityIndex": "0.47437722828194284",
-            "collateralIndex": "0.650938778285884"
+            "score": "5.0",
+            "liquidityIndex": "0.3591455827211757",
+            "collateralIndex": "0.9641151570215092",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "eth",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.3",
-            "liquidityIndex": "0.4955242141591791",
-            "collateralIndex": "0.9625175637003424"
+            "score": "5.1",
+            "liquidityIndex": "0.500195622764581",
+            "collateralIndex": "0.9800844213767133",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "usdc",
         "protocol": "nuo",
         "metrics": {
-            "score": "3.9",
-            "liquidityIndex": "0.49146829625728883",
-            "collateralIndex": "0.5634932544857769"
+            "score": "5.2",
+            "liquidityIndex": "0.6022016797263983",
+            "collateralIndex": "0.9281193666782575",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.45889431770866274",
-            "collateralIndex": "0.929570480595231"
+            "score": "4.9",
+            "liquidityIndex": "0.37875550410017317",
+            "collateralIndex": "0.8299217965356218",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "rep",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.1",
-            "liquidityIndex": "0.24626505549825237",
-            "collateralIndex": "0.9755230574856182"
+            "score": "4.8",
+            "liquidityIndex": "0.15878227326997205",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "link",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.3",
-            "liquidityIndex": "0.39908471441641435",
-            "collateralIndex": "1.0"
+            "score": "4.9",
+            "liquidityIndex": "0.29020428184926017",
+            "collateralIndex": "0.9542043391908062",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "knc",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.377908868817463",
-            "collateralIndex": "0.9609511187382254"
+            "score": "5.0",
+            "liquidityIndex": "0.3619962744415894",
+            "collateralIndex": "0.9817101137955135",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "mkr",
         "protocol": "nuo",
         "metrics": {
-            "score": "3.8",
-            "liquidityIndex": "0.11431837734291385",
-            "collateralIndex": "0.864946496690706"
+            "score": "4.9",
+            "liquidityIndex": "0.22722757821294579",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "tusd",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.0",
-            "liquidityIndex": "0.22170459126492265",
-            "collateralIndex": "0.9484588495076368"
+            "score": "4.8",
+            "liquidityIndex": "0.1729525577651577",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "bat",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.2",
-            "liquidityIndex": "0.32620431044203163",
-            "collateralIndex": "1.0"
+            "score": "4.9",
+            "liquidityIndex": "0.2510524129421067",
+            "collateralIndex": "0.9603214017827858",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "snx",
         "protocol": "nuo",
         "metrics": {
-            "score": "3.3",
-            "liquidityIndex": "0.17133757074295683",
-            "collateralIndex": "0.2764297815761211"
+            "score": "4.2",
+            "liquidityIndex": "0.1616439484644266",
+            "collateralIndex": "0.3364865175149261",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "dai",
         "protocol": "nuo",
         "metrics": {
-            "score": "4.1",
-            "liquidityIndex": "0.3063148618614177",
-            "collateralIndex": "0.8864859542771436"
-        }
-    },
-    {
-        "asset": "eth",
-        "protocol": "ddex",
-        "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.41484141510829287",
-            "collateralIndex": "0.6818202327267436"
+            "score": "5.1",
+            "liquidityIndex": "0.48400769844273045",
+            "collateralIndex": "0.9308511111705482",
+            "timeIndex": "0.7850855200607274"
         }
     },
     {
         "asset": "sai",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.4",
-            "liquidityIndex": "0.20905176355962377",
-            "collateralIndex": "1.0"
+            "score": "6.0",
+            "liquidityIndex": "0.2735995350876018",
+            "collateralIndex": "1.0",
+            "timeIndex": "0.40126680288478234"
+        }
+    },
+    {
+        "asset": "eth",
+        "protocol": "ddex",
+        "metrics": {
+            "score": "5.5",
+            "liquidityIndex": "0.4541133885342506",
+            "collateralIndex": "0.38973788698425027",
+            "timeIndex": "0.40126680288478234"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.2",
-            "liquidityIndex": "0.0",
-            "collateralIndex": "1.0"
+            "score": "5.0",
+            "liquidityIndex": "0.0803073647534594",
+            "collateralIndex": "0.25243229878709694",
+            "timeIndex": "0.40126680288478234"
         }
     },
     {
         "asset": "dai",
         "protocol": "ddex",
         "metrics": {
-            "score": "6.7",
-            "liquidityIndex": "0.16679009894312483",
-            "collateralIndex": "0.29483877195737307"
+            "score": "5.3",
+            "liquidityIndex": "0.11711964209013104",
+            "collateralIndex": "0.4462543222234613",
+            "timeIndex": "0.40126680288478234"
         }
     },
     {
         "asset": "usdt",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.4",
-            "liquidityIndex": "0.516365595540751",
-            "collateralIndex": "0.6828241519110949"
-        }
-    },
-    {
-        "asset": "dai",
-        "protocol": "ddex",
-        "metrics": {
-            "score": "6.7",
-            "liquidityIndex": "0.16679009894312483",
-            "collateralIndex": "0.29483877195737307"
+            "score": "5.7",
+            "liquidityIndex": "0.5756819411744439",
+            "collateralIndex": "0.3807064055676237",
+            "timeIndex": "0.40126680288478234"
         }
     },
     {
         "asset": "usdc",
         "protocol": "ddex",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.41369657929516535",
-            "collateralIndex": "0.6370222935619521"
+            "score": "6.1",
+            "liquidityIndex": "0.5011890074242966",
+            "collateralIndex": "0.9247699925876371",
+            "timeIndex": "0.40126680288478234"
         }
     },
     {
         "asset": "eth",
         "protocol": "aave",
         "metrics": {
-            "score": "7.7",
-            "liquidityIndex": "0.5792249358368281",
-            "collateralIndex": "0.906105758829674"
+            "score": "6.7",
+            "liquidityIndex": "0.7711534579432506",
+            "collateralIndex": "0.956189295597801",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "usdc",
         "protocol": "aave",
         "metrics": {
-            "score": "6.5",
-            "liquidityIndex": "0.14367881930077772",
-            "collateralIndex": "0.1444836592127835"
+            "score": "6.2",
+            "liquidityIndex": "0.7329874675437803",
+            "collateralIndex": "0.4471238541978182",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "wbtc",
         "protocol": "aave",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.35026487531604217",
-            "collateralIndex": "0.9886607491285847"
+            "score": "6.5",
+            "liquidityIndex": "0.55091147702357",
+            "collateralIndex": "0.9307382100514614",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "link",
         "protocol": "aave",
         "metrics": {
-            "score": "7.8",
-            "liquidityIndex": "0.628882654462202",
-            "collateralIndex": "0.9578723708843812"
+            "score": "6.8",
+            "liquidityIndex": "0.8729191556490385",
+            "collateralIndex": "0.993143456864787",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "zrx",
         "protocol": "aave",
         "metrics": {
-            "score": "7.4",
-            "liquidityIndex": "0.22743707697439935",
-            "collateralIndex": "0.9863847824351871"
+            "score": "6.4",
+            "liquidityIndex": "0.40284728287616167",
+            "collateralIndex": "0.9728872159500537",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "knc",
         "protocol": "aave",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.38008699179130556",
-            "collateralIndex": "0.9927140661481465"
+            "score": "6.6",
+            "liquidityIndex": "0.6453386291258326",
+            "collateralIndex": "0.9482715616960512",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "dai",
         "protocol": "aave",
         "metrics": {
-            "score": "6.9",
-            "liquidityIndex": "0.3726542025758556",
-            "collateralIndex": "0.31406386068626013"
+            "score": "6.0",
+            "liquidityIndex": "0.5543368195712035",
+            "collateralIndex": "0.42108958335941105",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "bat",
         "protocol": "aave",
         "metrics": {
-            "score": "7.5",
-            "liquidityIndex": "0.2613347656968942",
-            "collateralIndex": "0.9863965967487084"
+            "score": "6.3",
+            "liquidityIndex": "0.462781830521867",
+            "collateralIndex": "0.887393569839915",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "lend",
         "protocol": "aave",
         "metrics": {
-            "score": "7.7",
-            "liquidityIndex": "0.5390248728301618",
-            "collateralIndex": "0.9701305245817321"
+            "score": "6.8",
+            "liquidityIndex": "0.802089785443487",
+            "collateralIndex": "0.9986660974859555",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "mkr",
         "protocol": "aave",
         "metrics": {
-            "score": "7.6",
-            "liquidityIndex": "0.34688313143566507",
-            "collateralIndex": "0.9901367581952748"
+            "score": "6.4",
+            "liquidityIndex": "0.45746508531740304",
+            "collateralIndex": "0.9686467721333125",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "tusd",
         "protocol": "aave",
         "metrics": {
-            "score": "6.8",
-            "liquidityIndex": "0.2890720636500724",
-            "collateralIndex": "0.32562061607566417"
+            "score": "6.3",
+            "liquidityIndex": "0.6924054721529364",
+            "collateralIndex": "0.6661686387736898",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "usdt",
         "protocol": "aave",
         "metrics": {
-            "score": "6.9",
-            "liquidityIndex": "0.47108282708875243",
-            "collateralIndex": "0.1954530861016215"
+            "score": "5.9",
+            "liquidityIndex": "0.673637858238819",
+            "collateralIndex": "0.29507518583853454",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "snx",
         "protocol": "aave",
         "metrics": {
-            "score": "7.3",
-            "liquidityIndex": "0.3433427799790493",
-            "collateralIndex": "0.7889756186347942"
+            "score": "5.7",
+            "liquidityIndex": "0.34855942572980064",
+            "collateralIndex": "0.34585802624491246",
+            "timeIndex": "0.14892685964837105"
         }
     },
     {
         "asset": "susd",
         "protocol": "aave",
         "metrics": {
-            "score": "7.0",
-            "liquidityIndex": "0.23730729786462135",
-            "collateralIndex": "0.5191217411798812"
+            "score": "6.5",
+            "liquidityIndex": "0.6730634659270887",
+            "collateralIndex": "0.8058098471388426",
+            "timeIndex": "0.14892685964837105"
+        }
+    },
+    {
+        "asset": "dai",
+        "protocol": "mcd",
+        "metrics": {
+            "score": 9.7
         }
     }
 ]

--- a/implementation/finance_service.py
+++ b/implementation/finance_service.py
@@ -1,5 +1,5 @@
 import json, requests, time, math
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import pandas as pd
 import numpy as np
 from pandas_datareader import data as pdr
@@ -28,7 +28,6 @@ def getCryptoCompareReturns(token):
     returns = df.copy().pct_change().fillna(value=0, axis=0).rename(columns={'close': f'daily_returns_{token}'})
     return returns
     
-# TODO - Fix Dates
 # Used to find historical USD values for all coins but stablecoins      
 def getReturns(tokens): 
     last_date = datetime.today().strftime('%Y-%m-%d')
@@ -39,7 +38,7 @@ def getReturns(tokens):
             token = token['token'][1:].upper()
         else:
             token = token['token'].upper()
-        if (token in ['DAI', 'USDC', 'MKR', 'TUSD', 'USDT', 'SAI', 'SUSD', 'SNX']):
+        if (token in ['DAI', 'USDC', 'MKR', 'TUSD', 'USDT', 'SAI', 'SUSD', 'SNX', 'LEND']):
             if token == 'SAI':
                 token = 'DAI'
             ticker_returns = getCryptoCompareReturns(token)
@@ -90,3 +89,8 @@ def normalize_data(val, list):
     max_value = max(list)
     min_value = min(list)
     return (val - min_value) / (max_value - min_value)
+
+def normalize_time_data(val, list):
+    max_value = int(datetime.now(tz=timezone.utc).timestamp())
+    min_value = min(list)
+    return 1 - ((val - min_value) / (max_value - min_value))

--- a/implementation/pool_data_service.py
+++ b/implementation/pool_data_service.py
@@ -35,20 +35,20 @@ def create_pool_data_object(token, total_supply, total_borrow, collateral=0):
   return pool_data
 
 def get_all_available_pools():
-    all_available_pools = []
-    for t in constants.dydxContractInfo['activeMarkets']:
-      all_available_pools.append({ 'protocol': 'dydx', 'token': t })
-    for t in constants.compoundContractInfo:
-      all_available_pools.append({ 'protocol': 'compound', 'token': t['token'] })
-    for t in constants.fulcrumContractInfo:
-      all_available_pools.append({ 'protocol': 'fulcrum', 'token': t['token'] })
-    for t in constants.nuoContractInfo:
-      all_available_pools.append({ 'protocol': 'nuo', 'token': t['token'] })
-    for t in constants.ddexContractInfo:
-      all_available_pools.append({ 'protocol': 'ddex', 'token': t['token'] })
-    for t in constants.aaveContractInfo:
-      all_available_pools.append({ 'protocol': 'aave', 'token': t['token'] })
-    return all_available_pools
+  all_available_pools = []
+  for t in constants.dydxContractInfo['activeMarkets']:
+    all_available_pools.append({ 'protocol': 'dydx', 'token': t })
+  for t in constants.compoundContractInfo:
+    all_available_pools.append({ 'protocol': 'compound', 'token': t['token'] })
+  for t in constants.fulcrumContractInfo:
+    all_available_pools.append({ 'protocol': 'fulcrum', 'token': t['token'] })
+  for t in constants.nuoContractInfo:
+    all_available_pools.append({ 'protocol': 'nuo', 'token': t['token'] })
+  for t in constants.ddexContractInfo:
+    all_available_pools.append({ 'protocol': 'ddex', 'token': t['token'] })
+  for t in constants.aaveContractInfo:
+    all_available_pools.append({ 'protocol': 'aave', 'token': t['token'] })
+  return all_available_pools
 
 def fetch_data_for_nuo_pool(token):
   # Have to fetch the data from the API for now because fetching outstandingDebt from Nuo is challenging
@@ -72,15 +72,15 @@ def fetch_data_for_compound_pool(token):
   return result
 
 def fetch_data_for_dydx_pool(token):
-    shift_by = 6 if token == 'usdc'  else 18
-    pool_info = constants.dydxContractInfo['markets'].index(token)
-    initializedContract = web3_service.initializeContract(constants.dydxContractInfo['contractAddress'], abi=constants.dydx_abi_string)
-    pool_data = initializedContract.functions.getMarketWithInfo(pool_info).call()
-    # Grab + calculate data from dydx market info structure
-    total_supply = pool_data[0][1][1] / 10 ** shift_by
-    total_borrow = pool_data[0][1][0] / 10 ** shift_by
-    result = create_pool_data_object(token, total_supply, total_borrow)
-    return result
+  shift_by = 6 if token == 'usdc'  else 18
+  pool_info = constants.dydxContractInfo['markets'].index(token)
+  initializedContract = web3_service.initializeContract(constants.dydxContractInfo['contractAddress'], abi=constants.dydx_abi_string)
+  pool_data = initializedContract.functions.getMarketWithInfo(pool_info).call()
+  # Grab + calculate data from dydx market info structure
+  total_supply = pool_data[0][1][1] / 10 ** shift_by
+  total_borrow = pool_data[0][1][0] / 10 ** shift_by
+  result = create_pool_data_object(token, total_supply, total_borrow)
+  return result
 
 
 def fetch_data_for_fulcrum_pool(token):

--- a/whitepaper.md
+++ b/whitepaper.md
@@ -56,19 +56,16 @@ While no smart contract can be guaranteed as safe and free of bugs, a thorough c
 
 Our model assesses code security by looking at three pieces of off-chain but public data:
 
-1. Audited Code: The first is whether the code been audited by a reputable security team (Consensys Diligence, Trail of Bits, others??).
-2. Formal Verification:The second data point is whether the code has been formally verified by a reputable security team.
-3. Bounty Program:The third data point is whether the development team offers a public bug bounty program.
-
+  1. **Time on Mainnet - (25%):** Normalized time since the protocol first launched on mainnet
+  2. **No Critical Vulnerabilities:** No vulnerabilities have been exploited
+  3. **Four Engineer Weeks** 4 or more engineer weeks have been dedicated to auditing the protocol
+  4. **Public Audit:** Has the audit report been made public
+  5. **Recent Audit:** Has there been an audit in the last 12 months **OR** have no code changes been made
+  6. **Bounty Program:** Does the development team offers a public bug bounty program?
 
 <sup>3</sup>Securities and Exchange Commission, Release No. 81207, https://www.sec.gov/litigation/investreport/34‐81207.pdf (“SEC DAO Report”) at 1.
 
 <sup>4</sup>Id. at 9. The DAO hack funds were ultimately recovered through an extraordinary “fork” of the Ethereum blockchain, id., but such forks cannot be expected to recover from future hacks.
-
-#### Code Openness
-Part of the promise of DeFi is that the functionality of smart contracts is completely on-chain, which means the code is verifiable and transparent. Developers of DeFi platforms still have the ability to obscure their code in various ways, such as not verifying the bytecode and using off chain oracles processes. Security through obscurity offers weak security guarantees at best, and at worst results in delays in finding critical bugs. While bytecode decompilation is possible, it is a difficult and time-consuming process and makes it hard to follow the mantra of “don’t trust, verify”.
-
-Code openness is assessed by looking at a single data point of off-chain but public data, whether the byte code has been verified.
 
 ### Financial Risk
 DeFi contains many of the same risks as legacy finance. While most lending platforms use over-collateralization to reduce credit risk, over-collateralization does not completely remove credit risk. Crypto assets are notoriously volatile and these platforms have no method to recover from system insolvency caused by volatile collateral assets.
@@ -128,10 +125,13 @@ Another large element of centralization risk in these protocols is oracle centra
 ## Formula Breakdown
 
 1. Smart Contract Risk (45%)
-* Audited code (25%)
-* All code’s byte source verified (10%)
-* Formal Verification (5%)
-* Bug Bounty Program (5%)
+* Time on Mainnet (11.25%)
+* No Critical Vulnerabilities (9%)
+* Engineering Weeks (4.5%)
+* Recent Audit or no code changes (6.75%)
+* Public Audit (6.75%)
+* Bug Bounty (6.75%)
+
 
 2. Financial Risk (30%)
 * Collateral Makeup CVaR (10%)


### PR DESCRIPTION
### Overview
This proposal outlines a new, more robust set of audit requirements for DeFi Score. 

### Problem Statement
The original version of DeFi Score used a simple boolean value on whether or not a DeFi protocol’s smart contracts were audited or not. A boolean value does not capture the complexity that is inherent in smart contract security auditing. All audits are not created equal. There are many facets of a smart contract audit that help determine its quality and the security of the underlying protocol.

In light of recent events in the DeFi ecosystem, we have decided to propose a more robust framework for evaluating smart contract audits and the underlying protocols level of security. We hope that these guidelines will better capture the full spectrum of how different DeFi products approach security.

There is no silver bullet for smart contract security. Audits performed over many engineering weeks by security firms with sterling reputations still miss critical and high severity issues. That being said, a rigorous approach to security helps minimize the probability of such events.


### Proposal

- There are many factors that determine the quality of a smart contract audit, including
- How many engineering weeks went into the audit
- Is the audit report public or private
- Who were the auditors
- Were all of the critical and high severity issues addressed

**Protocol’s security:**

- How many audits have been completed
- Time on mainnet without exploit
- How much has code been updated since the last audit
- Have there been any critical vulnerabilities since the last audit
- Has an economic audit been performed
- Has Sam Sun looked at it (jk but not really)

Teams like Compound have been extremely diligent about continually auditing their protocol’s code as they introduce new functionality and code modules, while other teams have taken a more lax approach, with the last audit happening a year or 18 months ago. The guidelines below hopefully better capture the different levels of rigor better than the previous iteration of our audit guidelines

**The proposed requirements for receiving audit credit are now:**

- Minimum of 4 total engineering weeks dedicated to audits (10%)
- No critical vulnerabilities reported since the audit (20%)
- An audit has taken place in the last 12 months OR there have been minimal code changes since the last audit (15%)
- Normalized time on mainnet without exploit (0 -1) (25%)
- Audit results must be released publicly  (15%)
- Has a bounty program and security disclosure information (15%)

A simple score is never going to capture the complexity of security auditing and is not necessarily meant to. Abstractions are always leaky. Most people, even in the DeFi ecosystem, do not have the capabilities/skill set to independently verify the security of smart contract protocols. It is our hope that these guidelines help set a minimum standard for team’s approach to security and allows for laypeople to make better decisions about how safe it is to deposit their money in different protocols. 




### Alternatives
**Have a centrally managed list of supported audit firms**
This is a concept we’ve discussed in the past, but it seems hard to manage and might be seen as biased since there may be conflicts of interest with Diligence
**Using some time decay function that lowers the security score of a protocol based on time since the last audit**
Something like this could definitely be useful, but it seems rather reductive because an audit may only cover a new module, which does not provide any guarantees on other modules that may have changed. This is also contrary to the idea that being onchain without being hacked for more time is a good proxy of security. (assuming no upgrades).

ie. Uniswap shouldn't have to reaudit the same code every year.

### Open Questions

1. Do we have any recommendations/guidelines for economic audits?
2. How do we keep track of vulnerabilities and audit results?
3. How do we give credit to teams that may have a more internal security function


